### PR TITLE
Release

### DIFF
--- a/front/admin-casademiranda/auth/auth.ts
+++ b/front/admin-casademiranda/auth/auth.ts
@@ -4,3 +4,16 @@ export function getToken() {
   }
   return null;
 }
+
+export function getRole(): string | null {
+  const token = getToken();
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.role ?? null;
+  } catch { return null; }
+}
+
+export function isAdmin(): boolean {
+  return getRole() === 'admin';
+}

--- a/front/admin-casademiranda/components/navbar/navbar.tsx
+++ b/front/admin-casademiranda/components/navbar/navbar.tsx
@@ -6,22 +6,26 @@ import Image from "next/image";
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { getRole } from '@/auth/auth';
 
 const NAV_LINKS = [
-    { href: '/', label: 'Reservas', exact: true },
-    { href: '/booking/new-booking', label: 'Crear reserva' },
-    { href: '/booking/load-booking', label: 'Cargar reservas' },
-    { href: '/menu', label: 'Carta de cenas' },
-    { href: '/precios-base', label: 'Precios base' },
+    { href: '/', label: 'Reservas', exact: true, adminOnly: false },
+    { href: '/booking/new-booking', label: 'Crear reserva', adminOnly: false },
+    { href: '/booking/load-booking', label: 'Cargar reservas', adminOnly: false },
+    { href: '/menu', label: 'Carta de cenas', adminOnly: false },
+    { href: '/precios-base', label: 'Precios base', adminOnly: false },
+    { href: '/usuarios', label: 'Usuarios', adminOnly: true },
 ];
 
 export default function DefaultNavbar() {
     const router = useRouter();
     const [token, setToken] = useState<string | null>(null);
+    const [role, setRole] = useState<string | null>(null);
 
     useEffect(() => {
         const tokenGuardado = localStorage.getItem('token');
         if (tokenGuardado) setToken(tokenGuardado);
+        setRole(getRole());
     }, []);
 
     function isActive(href: string, exact?: boolean) {
@@ -42,7 +46,7 @@ export default function DefaultNavbar() {
             </Navbar.Brand>
             <Navbar.Toggle />
             <Navbar.Collapse>
-                {NAV_LINKS.map(({ href, label, exact }) => (
+                {NAV_LINKS.filter(({ adminOnly }) => !adminOnly || role === 'admin').map(({ href, label, exact }) => (
                     <Link key={href} href={href}>
                         <span className={`
                             text-sm font-semibold px-1 py-0.5 rounded transition-colors

--- a/front/admin-casademiranda/pages/precios-base/index.tsx
+++ b/front/admin-casademiranda/pages/precios-base/index.tsx
@@ -3,6 +3,7 @@ import Navbar from "@/components/navbar/navbar";
 import { useEffect, useState } from "react";
 import type { RoomBasePrice, SeasonConfig } from "@/interfaces/roomPrice";
 import * as API from "@/services/roomPrices";
+import { isAdmin } from "@/auth/auth";
 
 const ROOMS = ['A Fonte', 'O Carpinteiro', 'O Cuberto', 'O Faiado'];
 
@@ -13,6 +14,7 @@ export default function PreciosBasePage() {
     const [seasonEdited, setSeasonEdited] = useState<SeasonConfig | null>(null);
     const [saving, setSaving] = useState(false);
     const [saved, setSaved] = useState(false);
+    const [canEdit] = useState(isAdmin());
 
     useEffect(() => { load(); }, []);
 
@@ -66,7 +68,7 @@ export default function PreciosBasePage() {
             <div className="px-4 md:px-10 mt-5">
                 <div className="flex items-center justify-between mb-5">
                     <h1 className="text-xl text-green text-opacity-75 font-semibold">Precios base</h1>
-                    {hasChanges && (
+                    {canEdit && hasChanges && (
                         <button
                             onClick={handleSave}
                             disabled={saving}
@@ -88,6 +90,7 @@ export default function PreciosBasePage() {
                                 className={inputClass + " w-full"}
                                 value={season.high_season_start}
                                 placeholder="06-15"
+                                disabled={!canEdit}
                                 onChange={e => setSeasonEdited({ ...season, high_season_start: e.target.value })}
                             />
                         </div>
@@ -97,6 +100,7 @@ export default function PreciosBasePage() {
                                 className={inputClass + " w-full"}
                                 value={season.high_season_end}
                                 placeholder="09-15"
+                                disabled={!canEdit}
                                 onChange={e => setSeasonEdited({ ...season, high_season_end: e.target.value })}
                             />
                         </div>
@@ -124,6 +128,7 @@ export default function PreciosBasePage() {
                                                     <input
                                                         className="border border-gray-light rounded-lg px-2 py-1 text-sm text-gray-dark w-full text-right focus:outline-none"
                                                         type="number" min="0" step="0.01"
+                                                        disabled={!canEdit}
                                                         value={getEdited(row.id, 'price', row.price)}
                                                         onChange={e => setEditedField(row.id, 'price', e.target.value)}
                                                     />
@@ -136,6 +141,7 @@ export default function PreciosBasePage() {
                                                     <input
                                                         className="border border-gray-light rounded-lg px-2 py-1 text-sm text-gray-dark w-full text-right focus:outline-none"
                                                         type="number" min="0" step="0.01"
+                                                        disabled={!canEdit}
                                                         value={getEdited(row.id, 'price_extra_bed', row.price_extra_bed)}
                                                         onChange={e => setEditedField(row.id, 'price_extra_bed', e.target.value)}
                                                     />
@@ -176,12 +182,14 @@ export default function PreciosBasePage() {
                                             </td>
                                             <td className="px-4 py-3 text-right">
                                                 <input className={inputClass} type="number" min="0" step="0.01"
+                                                    disabled={!canEdit}
                                                     value={getEdited(row.id, 'price', row.price)}
                                                     onChange={e => setEditedField(row.id, 'price', e.target.value)} />
                                                 <span className="ml-1 text-gray">€</span>
                                             </td>
                                             <td className="px-4 py-3 text-right">
                                                 <input className={inputClass} type="number" min="0" step="0.01"
+                                                    disabled={!canEdit}
                                                     value={getEdited(row.id, 'price_extra_bed', row.price_extra_bed)}
                                                     onChange={e => setEditedField(row.id, 'price_extra_bed', e.target.value)} />
                                                 <span className="ml-1 text-gray">€</span>

--- a/front/admin-casademiranda/pages/usuarios/index.tsx
+++ b/front/admin-casademiranda/pages/usuarios/index.tsx
@@ -1,0 +1,217 @@
+import "@/app/globals.css";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Navbar from '@/components/navbar/navbar';
+import { isAdmin } from '@/auth/auth';
+import { getUsers, createManagedUser, deleteManagedUser, changePassword, ManagedUser } from '@/services/users';
+
+const inputClass = "mt-1 w-full border border-gray-light rounded-lg px-3 py-2 text-gray-dark text-sm focus:outline-none focus:border-gray";
+const labelClass = "text-xs text-gray uppercase tracking-wide block";
+
+export default function Usuarios() {
+    const router = useRouter();
+    const [users, setUsers] = useState<ManagedUser[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const [role, setRole] = useState<'admin' | 'manager'>('manager');
+    const [creating, setCreating] = useState(false);
+    const [createError, setCreateError] = useState('');
+
+    const [pwdUser, setPwdUser] = useState<ManagedUser | null>(null);
+    const [newPassword, setNewPassword] = useState('');
+    const [changingPwd, setChangingPwd] = useState(false);
+    const [pwdError, setPwdError] = useState('');
+
+    useEffect(() => {
+        if (!isAdmin()) { router.replace('/'); return; }
+        load();
+    }, []);
+
+    async function load() {
+        setLoading(true);
+        try {
+            setUsers(await getUsers());
+        } catch (e: any) {
+            setError(e.message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function handleCreate(e: React.FormEvent) {
+        e.preventDefault();
+        if (!username.trim() || !password.trim()) {
+            setCreateError('Usuario y contraseña son obligatorios');
+            return;
+        }
+        setCreating(true);
+        setCreateError('');
+        try {
+            await createManagedUser(username.trim(), password, role);
+            setUsername('');
+            setPassword('');
+            setRole('manager');
+            await load();
+        } catch (e: any) {
+            setCreateError(e.message);
+        } finally {
+            setCreating(false);
+        }
+    }
+
+    async function handleDelete(id: number, name: string) {
+        if (!confirm(`¿Eliminar el usuario "${name}"?`)) return;
+        try {
+            await deleteManagedUser(id);
+            await load();
+        } catch (e: any) {
+            alert(`Error: ${e.message}`);
+        }
+    }
+
+    function openPwdModal(u: ManagedUser) {
+        setPwdUser(u);
+        setNewPassword('');
+        setPwdError('');
+    }
+
+    async function handleChangePassword(e: React.FormEvent) {
+        e.preventDefault();
+        if (!newPassword.trim()) { setPwdError('La contraseña no puede estar vacía'); return; }
+        if (!pwdUser) return;
+        setChangingPwd(true);
+        setPwdError('');
+        try {
+            await changePassword(pwdUser.id, newPassword);
+            setPwdUser(null);
+        } catch (e: any) {
+            setPwdError(e.message);
+        } finally {
+            setChangingPwd(false);
+        }
+    }
+
+    const roleBadge = (r: string) => r === 'admin'
+        ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold bg-green bg-opacity-20 text-gray-dark">Admin</span>
+        : <span className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold bg-gray-light text-gray-dark">Manager</span>;
+
+    return (
+        <>
+            <Navbar />
+            <div className="px-4 md:px-10 mt-5">
+                <h1 className="text-xl text-green text-opacity-75 font-semibold mb-5">Gestión de usuarios</h1>
+
+                {/* Crear usuario */}
+                <section className="border border-gray-light rounded-lg p-4 mb-6">
+                    <h2 className="text-xs text-gray uppercase tracking-wide font-semibold mb-3">Nuevo usuario</h2>
+                    <form onSubmit={handleCreate} noValidate>
+                        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+                            <div>
+                                <label className={labelClass}>Usuario</label>
+                                <input className={inputClass} type="text" value={username}
+                                    onChange={e => setUsername(e.target.value)} />
+                            </div>
+                            <div>
+                                <label className={labelClass}>Contraseña</label>
+                                <input className={inputClass} type="password" value={password}
+                                    onChange={e => setPassword(e.target.value)} />
+                            </div>
+                            <div>
+                                <label className={labelClass}>Rol</label>
+                                <select className={inputClass} value={role} onChange={e => setRole(e.target.value as 'admin' | 'manager')}>
+                                    <option value="manager">Manager</option>
+                                    <option value="admin">Admin</option>
+                                </select>
+                            </div>
+                            <div>
+                                <button type="submit" disabled={creating}
+                                    className="w-full rounded-full bg-green bg-opacity-50 px-4 py-2 text-sm font-semibold text-gray-dark disabled:opacity-40">
+                                    {creating ? 'Creando...' : 'Crear usuario'}
+                                </button>
+                            </div>
+                        </div>
+                        {createError && <p className="text-xs text-orange mt-2">{createError}</p>}
+                    </form>
+                </section>
+
+                {/* Lista de usuarios */}
+                <section className="border border-gray-light rounded-lg p-4">
+                    <h2 className="text-xs text-gray uppercase tracking-wide font-semibold mb-3">Usuarios</h2>
+
+                    {loading ? (
+                        <p className="text-sm text-gray">Cargando...</p>
+                    ) : error ? (
+                        <p className="text-sm text-orange">{error}</p>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="border-b border-gray-light">
+                                        <th className="text-left py-2 px-3 text-xs text-gray uppercase tracking-wide font-semibold">Usuario</th>
+                                        <th className="text-left py-2 px-3 text-xs text-gray uppercase tracking-wide font-semibold">Rol</th>
+                                        <th className="py-2 px-3"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {users.map(u => (
+                                        <tr key={u.id} className="border-b border-gray-light last:border-0">
+                                            <td className="py-2 px-3 text-gray-dark font-medium">{u.username}</td>
+                                            <td className="py-2 px-3">{roleBadge(u.role)}</td>
+                                            <td className="py-2 px-3 text-right flex items-center justify-end gap-3">
+                                                <button onClick={() => openPwdModal(u)}
+                                                    title="Cambiar contraseña"
+                                                    className="text-gray hover:text-gray-dark transition-colors">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-4 h-4">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 0 1 21.75 8.25Z" />
+                                                    </svg>
+                                                </button>
+                                                <button onClick={() => handleDelete(u.id, u.username)}
+                                                    title="Eliminar usuario"
+                                                    className="text-gray hover:text-orange transition-colors">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-4 h-4">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                                    </svg>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </section>
+            </div>
+
+            {/* Modal cambio de contraseña */}
+            {pwdUser && (
+                <div className="fixed inset-0 bg-gray-dark bg-opacity-40 flex items-center justify-center z-50">
+                    <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-sm mx-4">
+                        <h3 className="text-sm font-semibold text-gray-dark mb-1">Cambiar contraseña</h3>
+                        <p className="text-xs text-gray mb-4">{pwdUser.username}</p>
+                        <form onSubmit={handleChangePassword} noValidate>
+                            <div className="mb-4">
+                                <label className={labelClass}>Nueva contraseña</label>
+                                <input className={inputClass} type="password" value={newPassword} autoFocus
+                                    onChange={e => setNewPassword(e.target.value)} />
+                                {pwdError && <p className="text-xs text-orange mt-1">{pwdError}</p>}
+                            </div>
+                            <div className="flex justify-end gap-3">
+                                <button type="button" onClick={() => setPwdUser(null)}
+                                    className="px-4 py-2 text-sm text-gray hover:text-gray-dark border border-gray-light rounded-full transition-colors">
+                                    Cancelar
+                                </button>
+                                <button type="submit" disabled={changingPwd}
+                                    className="px-4 py-2 text-sm font-semibold rounded-full bg-green bg-opacity-50 text-gray-dark disabled:opacity-40">
+                                    {changingPwd ? 'Guardando...' : 'Guardar'}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/front/admin-casademiranda/services/users.ts
+++ b/front/admin-casademiranda/services/users.ts
@@ -1,24 +1,70 @@
 import type { User } from '../interfaces/user'
+import { getToken } from '../auth/auth';
 import { API_HOST } from './config';
 
 const API_URL = `${API_HOST}/loginuser`;
 
-
 export async function login(user: User) {
     try {
-
         const requestOptions = {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(user)
         };
-
         const response = await fetch(`${API_URL}`, requestOptions);
         const data = await response.json();
         return data;
     } catch (error) {
         console.error(error);
     }
+}
+
+export interface ManagedUser {
+    id: number;
+    username: string;
+    role: 'admin' | 'manager';
+}
+
+export async function getUsers(): Promise<ManagedUser[]> {
+    const token = getToken();
+    const res = await fetch(`${API_HOST}/usuarios`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+}
+
+export async function createManagedUser(username: string, password: string, role: 'admin' | 'manager'): Promise<void> {
+    const token = getToken();
+    const res = await fetch(`${API_HOST}/usuarios`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ username, password, role })
+    });
+    if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message ?? `HTTP ${res.status}`);
+    }
+}
+
+export async function changePassword(id: number, password: string): Promise<void> {
+    const token = getToken();
+    const res = await fetch(`${API_HOST}/usuarios/${id}/password`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ password })
+    });
+    if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message ?? `HTTP ${res.status}`);
+    }
+}
+
+export async function deleteManagedUser(id: number): Promise<void> {
+    const token = getToken();
+    const res = await fetch(`${API_HOST}/usuarios/${id}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
 }

--- a/infrastructure/db/GH-68-user-roles.sql
+++ b/infrastructure/db/GH-68-user-roles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE casademiranda.users ADD COLUMN role ENUM('admin', 'manager') NOT NULL DEFAULT 'admin';

--- a/infrastructure/nginx/nginx.template.conf
+++ b/infrastructure/nginx/nginx.template.conf
@@ -72,6 +72,10 @@ http {
         proxy_pass http://backend;
     }
 
+    location /usuarios {
+        proxy_pass http://backend;
+    }
+
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {
         root /usr/share/nginx/html;

--- a/server/index.js
+++ b/server/index.js
@@ -236,10 +236,10 @@ app.post('/register', async (req, res) => {
             return res.status(500).json({ message: 'Error interno' });
         }
 
-        const newUser = await createUser(username, hashedPassword);
+        const newUser = await createUser(username, hashedPassword, 'admin');
         console.log('Usuario creado:', newUser);
 
-        const token = jwt.sign({ id: newUser.id }, SECRET_KEY, { expiresIn: '1h' });
+        const token = jwt.sign({ id: newUser.insertId, role: 'admin' }, SECRET_KEY, { expiresIn: '1h' });
         return res.status(201).json({ message: 'Usuario registrado con éxito', token });
     });
 });
@@ -257,7 +257,7 @@ app.post('/loginuser', async (req, res) => {
         return res.status(401).json({ message: 'Credenciales inválidas' });
     }
 
-    const token = jwt.sign({ id: user.id }, SECRET_KEY, { expiresIn: '1h' });
+    const token = jwt.sign({ id: user.id, role: user.role }, SECRET_KEY, { expiresIn: '1h' });
     return res.json({ message: 'Login correcto', token });
 });
 
@@ -735,13 +735,13 @@ app.get('/precios-base', async (req, res) => {
 });
 
 app.put('/precios-base/:id', async (req, res) => {
-    if (!authGuard(req, res)) return;
+    if (!adminGuard(req, res)) return;
     await updateBasePrice(req.params.id, req.body.price, req.body.price_extra_bed);
     res.sendStatus(200);
 });
 
 app.put('/precios-base/season-config', async (req, res) => {
-    if (!authGuard(req, res)) return;
+    if (!adminGuard(req, res)) return;
     await updateSeasonConfig(req.body.high_season_start, req.body.high_season_end);
     res.sendStatus(200);
 });
@@ -761,6 +761,16 @@ function authGuard(req, res) {
     const token = (req.headers['authorization'] ?? '').split(' ')[1];
     if (!token) { res.sendStatus(401); return false; }
     try { jwt.verify(token, SECRET_KEY); return true; } catch { res.sendStatus(403); return false; }
+}
+
+function adminGuard(req, res) {
+    const token = (req.headers['authorization'] ?? '').split(' ')[1];
+    if (!token) { res.sendStatus(401); return false; }
+    try {
+        const decoded = jwt.verify(token, SECRET_KEY);
+        if (decoded.role !== 'admin') { res.sendStatus(403); return false; }
+        return true;
+    } catch { res.sendStatus(403); return false; }
 }
 
 // Endpoint público — sin autenticación
@@ -798,6 +808,62 @@ app.delete('/menu/:id', async (req, res) => {
     if (!authGuard(req, res)) return;
     await deleteDish(parseInt(req.params.id));
     res.sendStatus(200);
+});
+
+// --- Gestión de usuarios (solo admin) ---
+
+app.get('/usuarios', async (req, res) => {
+    if (!adminGuard(req, res)) return;
+    try {
+        const users = await executeQuery('SELECT id, username, role FROM casademiranda.users ORDER BY id');
+        res.json(users);
+    } catch (err) {
+        console.error('Error listing users:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.post('/usuarios', async (req, res) => {
+    if (!adminGuard(req, res)) return;
+    const { username, password, role } = req.body;
+    if (!username || !password || !['admin', 'manager'].includes(role)) {
+        return res.status(400).json({ message: 'username, password y role (admin|manager) son requeridos' });
+    }
+    try {
+        const existing = await getUserByUsername(username);
+        if (existing) return res.status(409).json({ message: 'El usuario ya existe' });
+        const hash = await bcrypt.hash(password, 12);
+        await createUser(username, hash, role);
+        res.status(201).json({ message: 'Usuario creado' });
+    } catch (err) {
+        console.error('Error creating user:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.put('/usuarios/:id/password', async (req, res) => {
+    if (!adminGuard(req, res)) return;
+    const { password } = req.body;
+    if (!password) return res.status(400).json({ message: 'password es obligatorio' });
+    try {
+        const hash = await bcrypt.hash(password, 12);
+        await executeQuery('UPDATE casademiranda.users SET password_hash = ? WHERE id = ?', [hash, req.params.id]);
+        res.sendStatus(204);
+    } catch (err) {
+        console.error('Error changing password:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.delete('/usuarios/:id', async (req, res) => {
+    if (!adminGuard(req, res)) return;
+    try {
+        await executeQuery('DELETE FROM casademiranda.users WHERE id = ?', [req.params.id]);
+        res.sendStatus(204);
+    } catch (err) {
+        console.error('Error deleting user:', err);
+        res.status(500).json({ error: err.message });
+    }
 });
 
 app.listen(3003, function () {

--- a/server/users/getUser.js
+++ b/server/users/getUser.js
@@ -3,7 +3,7 @@ import executeQuery from '../sql/sqlUtils.js';
 
 const getUserByUsername = async (username) => {
     return new Promise((resolve, reject) => {
-        executeQuery('SELECT * FROM users WHERE username = ?', [username]).then((result, error) => {
+        executeQuery('SELECT * FROM casademiranda.users WHERE username = ?', [username]).then((result, error) => {
             if (error) reject(error);
             resolve(returnUser(result))
         })
@@ -16,9 +16,11 @@ const returnUser = (result) => {
         return false;
     }
 
-    return {id: result[0].id,
+    return {
+        id: result[0].id,
         username: result[0].username,
-        password: result[0].password_hash
+        password: result[0].password_hash,
+        role: result[0].role ?? 'admin',
     };
 }
 

--- a/server/users/saveUser.js
+++ b/server/users/saveUser.js
@@ -1,13 +1,11 @@
 import executeQuery from '../sql/sqlUtils.js';
 
 
-const createUser = async (username, hashedPassword) => {
-    return new Promise((resolve, reject) => {
-        executeQuery('INSERT INTO casademiranda.users (username, password_hash) VALUES (?, ?)', [username, hashedPassword]).then((result, error) => {
-            if (error) reject(error);
-            resolve(result)
-        })
-    })
+const createUser = async (username, hashedPassword, role = 'admin') => {
+    return executeQuery(
+        'INSERT INTO casademiranda.users (username, password_hash, role) VALUES (?, ?, ?)',
+        [username, hashedPassword, role]
+    );
 }
 
 export {createUser};


### PR DESCRIPTION
* feat: GH-68 gestión de usuarios con roles (admin/manager)

- Migración DB: columna role ENUM('admin','manager') en users
- JWT incluye role en login y register
- adminGuard para endpoints exclusivos de admin
- PUT /precios-base protegidos con adminGuard
- Endpoints CRUD /usuarios (solo admin)
- Nginx: añadir location /usuarios
- Frontend: getRole/isAdmin helpers en auth.ts
- Página /usuarios para gestión (solo admin)
- Navbar muestra "Usuarios" solo a admins



* fix: añadir try/catch a endpoints /usuarios para errores descriptivos



* feat: cambio de contraseña de usuario desde panel de admin



* fix: precios base en modo solo lectura para usuarios manager



---------