### PR TITLE
[GH-98]: Selector municipio con búsqueda

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ nginx (80→443 redirect, SSL termination)
 
 ## Despliegue (Raspberry Pi)
 
-- **IP estática**: `192.168.1.182` (configurada con nmcli, usuario: `pablo`, hostname: `genzo`)
+- **IP estática**: `192.168.1.171` (configurada con nmcli, usuario: `pablo`, hostname: `genzo`)
 - **Rama de producción**: `main`
 - **Arranque**: `infrastructure/launch-docker.sh` (hace `docker compose build frontend` antes que el resto para que nginx pueda copiar los estáticos)
 - **Base de datos**: exportar con `infrastructure/db-export.ps1` desde Windows, copiar con `scp` e importar con `infrastructure/db-import.sh`

--- a/front/admin-casademiranda/components/clients/MunicipioSelector.tsx
+++ b/front/admin-casademiranda/components/clients/MunicipioSelector.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+import { normalize } from '@/utils/municipioSearch';
+
+type Municipio = { codigo: string; municipio: string };
+
+interface Props {
+    municipios: Municipio[];
+    value: string;
+    onChange: (codigo: string) => void;
+}
+
+export function MunicipioSelector({ municipios, value, onChange }: Props) {
+    const [query, setQuery] = useState('');
+    const [open, setOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const m = municipios.find(m => m.codigo === value);
+        setQuery(m?.municipio ?? '');
+    }, [value, municipios]);
+
+    const filtered = query.length >= 2
+        ? municipios.filter(m => normalize(m.municipio).includes(normalize(query))).slice(0, 60)
+        : [];
+
+    useEffect(() => {
+        function onClickOutside(e: MouseEvent) {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+                const m = municipios.find(m => m.codigo === value);
+                setQuery(m?.municipio ?? '');
+            }
+        }
+        document.addEventListener('mousedown', onClickOutside);
+        return () => document.removeEventListener('mousedown', onClickOutside);
+    }, [value, municipios]);
+
+    return (
+        <div ref={containerRef} className="relative">
+            <input
+                type="text"
+                className="rounded-full w-full"
+                value={query}
+                placeholder="Buscar municipio..."
+                onChange={e => {
+                    setQuery(e.target.value);
+                    setOpen(true);
+                    if (!e.target.value) onChange('');
+                }}
+                onFocus={() => { if (query.length >= 2) setOpen(true); }}
+            />
+            {open && filtered.length > 0 && (
+                <ul className="absolute z-10 bg-white border border-gray-light rounded-lg mt-1 max-h-52 overflow-y-auto w-full shadow-md">
+                    {filtered.map(m => (
+                        <li
+                            key={m.codigo}
+                            className="px-3 py-1.5 text-sm text-gray-dark cursor-pointer hover:bg-gray-light"
+                            onMouseDown={() => {
+                                onChange(m.codigo);
+                                setQuery(m.municipio);
+                                setOpen(false);
+                            }}
+                        >
+                            {m.municipio}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/front/admin-casademiranda/pages/client/new-client.tsx
+++ b/front/admin-casademiranda/pages/client/new-client.tsx
@@ -9,6 +9,7 @@ import { parseDNI } from '@/services/clients';
 import type { Address, Client } from '@/interfaces/client';
 import { useRouter } from 'next/router';
 import { findMunicipioByName } from '@/utils/municipioSearch';
+import { MunicipioSelector } from '@/components/clients/MunicipioSelector';
 
 type Country = {
     pais: string;
@@ -378,17 +379,11 @@ export default function NewClient() {
                         {country === "ESP" ? (
                             <div className="grid grid-cols-1">
                                 <label className='text-gray-dark text-opacity-75' id="location">Municipio:</label>
-                                <select
-                                    className="rounded-full"
-                                    id="selector-location"
-                                    value={location || ''}
-                                    onChange={(e) => setLocation(e.target.value)}
-                                >
-                                    <option value="">-- Elige un municipio --</option>
-                                    {municipios.map(p => (
-                                        <option key={p.codigo} value={p.codigo}>{p.municipio}</option>
-                                    ))}
-                                </select>
+                                <MunicipioSelector
+                                    municipios={municipios}
+                                    value={location}
+                                    onChange={setLocation}
+                                />
                             </div>
                         ) : (
                             <div className="grid grid-cols-1">

--- a/front/admin-casademiranda/pages/client/update-client/[id].tsx
+++ b/front/admin-casademiranda/pages/client/update-client/[id].tsx
@@ -8,6 +8,7 @@ import { parseDNI } from '@/services/clients';
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { findMunicipioByName } from '@/utils/municipioSearch';
+import { MunicipioSelector } from '@/components/clients/MunicipioSelector';
 
 type Country = {
     pais: string;
@@ -340,17 +341,11 @@ export default function UpdateClient() {
                             {client.address?.country === "ESP" ? (
                                 <div className="grid grid-cols-1">
                                     <label className='text-gray-dark text-opacity-75' id="location">Municipio:</label>
-                                    <select
-                                        className="rounded-full"
-                                        id="selector-location"
+                                    <MunicipioSelector
+                                        municipios={municipios}
                                         value={client.address?.location || ''}
-                                        onChange={(e) => setClient({ ...client, address: { ...client.address, location: e.target.value } })}
-                                    >
-                                        <option value="">-- Elige un municipio --</option>
-                                        {municipios.map(p => (
-                                            <option key={p.codigo} value={p.codigo}>{p.municipio}</option>
-                                        ))}
-                                    </select>
+                                        onChange={(codigo) => setClient({ ...client, address: { ...client.address, location: codigo } })}
+                                    />
                                 </div>
                             ) : (
                                 <div className="grid grid-cols-1">

--- a/front/admin-casademiranda/services/config.ts
+++ b/front/admin-casademiranda/services/config.ts
@@ -1,1 +1,1 @@
-export const API_HOST = `https://${process.env.NEXT_PUBLIC_API_HOST ?? '192.168.1.182'}`;
+export const API_HOST = `https://${process.env.NEXT_PUBLIC_API_HOST ?? 'localhost'}`;

--- a/front/admin-casademiranda/utils/municipioSearch.ts
+++ b/front/admin-casademiranda/utils/municipioSearch.ts
@@ -1,6 +1,6 @@
 export type Municipio = { codigo: string; municipio: string };
 
-function normalize(s: string): string {
+export function normalize(s: string): string {
     return s
         .toLowerCase()
         .normalize('NFD')

--- a/infrastructure/.env.example
+++ b/infrastructure/.env.example
@@ -1,1 +1,7 @@
-API_HOST=192.168.1.182
+# Copia este fichero a .env y ajusta los valores para tu entorno
+# Este fichero SÍ se comitea; .env NO se comitea (gitignoreado)
+
+# IP o hostname de la máquina donde corre la app
+# Local:       192.168.1.176
+# Raspberry:   192.168.1.171
+API_HOST=

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -19,13 +19,13 @@ http {
 
   server {
     listen 80;
-    server_name 192.168.1.182;
+    server_name ${API_HOST};
     return 301 https://$host$request_uri;
   }
 
   server {
     listen 443 ssl;
-    server_name 192.168.1.182;
+    server_name ${API_HOST};
 
     ssl_certificate     /etc/nginx/infrastructure/certs/casademiranda.crt;
     ssl_certificate_key /etc/nginx/infrastructure/certs/casademiranda.key;


### PR DESCRIPTION
Closes #98

## Summary
- Nuevo componente `MunicipioSelector` con campo de texto filtrable (activa resultados a partir de 2 caracteres, máx. 60 resultados, normalización sin tildes)
- Sustituye el `<select>` plano de municipios en `new-client` y `update-client`
- Centraliza la configuración de IP en `infrastructure/.env` (gitignoreado): elimina hardcodes en `nginx.conf` y `services/config.ts`
- Añade `infrastructure/.env.example` como plantilla documentada

## Test plan
- [x] Crear nuevo cliente con país ESP → el campo municipio permite buscar por texto
- [x] Editar cliente existente con país ESP → el municipio pre-cargado aparece en el input y se puede cambiar
- [x] Escanear DNI → el municipio del OCR se auto-rellena en el buscador
- [x] Con país distinto de ESP → sigue apareciendo input de texto libre

🤖 Generated with [Claude Code](https://claude.com/claude-code)