### PR TITLE
[GH-100]: Acceso remoto seguro vía Tailscale + nginx

### DIFF
--- a/front/admin-casademiranda/services/config.ts
+++ b/front/admin-casademiranda/services/config.ts
@@ -1,1 +1,3 @@
-export const API_HOST = `https://${process.env.NEXT_PUBLIC_API_HOST ?? 'localhost'}`;
+export const API_HOST = process.env.NEXT_PUBLIC_API_HOST
+    ? `https://${process.env.NEXT_PUBLIC_API_HOST}`
+    : '';

--- a/infrastructure/compose.yaml
+++ b/infrastructure/compose.yaml
@@ -30,8 +30,6 @@ services:
   frontend:
     build:
       context: ../front/admin-casademiranda
-      args:
-        - NEXT_PUBLIC_API_HOST=${API_HOST}
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
Closes #100

## Summary
- Nuevo server block en nginx para `genzo.tailbbc079.ts.net` con certificado válido de Tailscale (sin avisos de seguridad)
- Templates de nginx separados por entorno (`nginx.local.template.conf` / `nginx.production.template.conf`) seleccionados via `ENVIRONMENT` en `.env`
- `snippets/proxy-locations.conf` extrae los location blocks, evitando duplicación
- Frontend usa URLs relativas — funciona con cualquier hostname sin recompilar
- `compose.yaml`: elimina `NEXT_PUBLIC_API_HOST` del build arg del frontend
- `tailscale-cert-renew.sh`: script para renovar el cert y reiniciar nginx
- `tailscale-certs/` añadido a `.gitignore`

## Pasos en la Raspberry antes de desplegar
```bash
# 1. Generar el certificado Tailscale
mkdir -p ~/registroreservas/infrastructure/tailscale-certs
sudo tailscale cert \
  --cert-file ~/registroreservas/infrastructure/tailscale-certs/genzo.tailbbc079.ts.net.crt \
  --key-file  ~/registroreservas/infrastructure/tailscale-certs/genzo.tailbbc079.ts.net.key \
  genzo.tailbbc079.ts.net

# 2. Actualizar .env
# ENVIRONMENT=production
# API_HOST=192.168.1.171
# TAILSCALE_HOSTNAME=genzo.tailbbc079.ts.net

# 3. Pull + rebuild
cd ~/registroreservas && git pull && cd infrastructure && bash launch-docker.sh
```

## Test plan
- [x] Acceso local `https://192.168.1.176` funciona (probado)
- [ ] Acceder a `https://genzo.tailbbc079.ts.net` desde dispositivo en el tailnet → sin aviso de certificado
- [ ] Login y navegación funcionan desde Tailscale

🤖 Generated with [Claude Code](https://claude.com/claude-code)