### PR TITLE
[GH-99]: Gestión de errores del escáner de DNI

### DIFF
--- a/front/admin-casademiranda/pages/client/new-client.tsx
+++ b/front/admin-casademiranda/pages/client/new-client.tsx
@@ -87,7 +87,14 @@ export default function NewClient() {
             }
             if (result.provincia) setProvince(result.provincia);
         } catch (err: any) {
-            setScanError(err.message);
+            const isPhotoError = /MRZ|líneas MRZ/i.test(err.message);
+            if (isPhotoError) {
+                setScanError('No se pudo leer el DNI. Comprueba que la foto sea nítida, el DNI ocupe casi toda la imagen y las 3 líneas de código del fondo sean visibles. Selecciona una nueva foto e inténtalo de nuevo.');
+                setBackFile(null);
+                setFrontFile(null);
+            } else {
+                setScanError(err.message);
+            }
         } finally {
             setScanning(false);
         }

--- a/front/admin-casademiranda/pages/client/update-client/[id].tsx
+++ b/front/admin-casademiranda/pages/client/update-client/[id].tsx
@@ -86,7 +86,14 @@ export default function UpdateClient() {
                 },
             });
         } catch (err: any) {
-            setScanError(err.message);
+            const isPhotoError = /MRZ|líneas MRZ/i.test(err.message);
+            if (isPhotoError) {
+                setScanError('No se pudo leer el DNI. Comprueba que la foto sea nítida, el DNI ocupe casi toda la imagen y las 3 líneas de código del fondo sean visibles. Selecciona una nueva foto e inténtalo de nuevo.');
+                setBackFile(null);
+                setFrontFile(null);
+            } else {
+                setScanError(err.message);
+            }
         } finally {
             setScanning(false);
         }


### PR DESCRIPTION
Closes #99

## Summary
- Cuando el OCR no detecta las líneas MRZ (error de calidad de foto), se muestra un mensaje claro y comprensible en lugar del error técnico
- Los archivos de foto se resetean automáticamente para que el usuario pueda seleccionar una nueva foto de inmediato
- Otros errores (red, servidor, etc.) siguen mostrando su mensaje original
- Aplica en `new-client` y `update-client`

## Test plan
- [x] Subir una foto de mala calidad → aparece el mensaje de "No se pudo leer el DNI..." y los selectores de foto vuelven a "Seleccionar"
- [x] Subir una foto válida → funciona con normalidad
- [x] Simular error de red → muestra el error genérico sin resetear la foto

🤖 Generated with [Claude Code](https://claude.com/claude-code)