### PR TITLE
[GH-93]: Limpiar archivos no trackeados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /server/facturas-cliente
 /infrastructure/tailscale-certs/
+/infrastructure/launch-docker.exe
 /server/node_modules
 /server/configuration/password.json
 /server/password.txt


### PR DESCRIPTION
Closes #93

## Summary
- Eliminado `winpty docker exec -it 42da263f475c5ab71.sql` de la raíz (comando ejecutado por error como nombre de fichero)
- Eliminado `server/diagramaAltaClientes.png` (archivo temporal)
- Añadido `infrastructure/launch-docker.exe` a `.gitignore` (binario compilado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)