### PR TITLE
[GH-113]: Actualizar estado a 'cancelada' al importar reservas canceladas desde Excel

### DIFF
--- a/server/routes/uploadBooking.js
+++ b/server/routes/uploadBooking.js
@@ -77,6 +77,7 @@ router.post('/upload-booking', upload.single("excelFile"), async function (req, 
 
         let reservasCreadas = 0;
         let reservasOmitidas = 0;
+        let reservasActualizadas = 0;
         const errores = [];
 
         for (const row of data) {
@@ -117,8 +118,19 @@ router.post('/upload-booking', upload.single("excelFile"), async function (req, 
                     'SELECT booking_id FROM casademiranda.bookings WHERE other_platform_reference = ?',
                     [referencia]
                 );
+                const estadoExcel = (row['Estado'] ?? '').toLowerCase().trim();
+                const esCancelada = ['cancelled', 'cancelada', 'cancelado', 'canceled'].includes(estadoExcel);
+
                 if (existing.length > 0) {
-                    reservasOmitidas++;
+                    if (esCancelada) {
+                        await executeQuery(
+                            "UPDATE casademiranda.bookings SET state = 'cancelada' WHERE other_platform_reference = ?",
+                            [referencia]
+                        );
+                        reservasActualizadas++;
+                    } else {
+                        reservasOmitidas++;
+                    }
                 } else {
                     await saveBooking(reserva, cliente);
                     reservasCreadas++;
@@ -137,6 +149,7 @@ router.post('/upload-booking', upload.single("excelFile"), async function (req, 
             message: "Archivo procesado correctamente",
             reservasCreadas,
             reservasOmitidas,
+            reservasActualizadas,
             errores,
         });
     } catch (err) {


### PR DESCRIPTION
## Summary

- Al importar un Excel de Booking.com, si una reserva ya existe en la BD y en el fichero aparece como cancelada, ahora se actualiza su `state` a `'cancelada'`
- La detección es case-insensitive: cubre `cancelled`, `canceled`, `cancelada`, `cancelado`
- La respuesta del endpoint incluye el nuevo campo `reservasActualizadas`

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)