### PR TITLE
[GH-113]: Lista explícita de estados de cancelación de Booking.com

### DIFF
--- a/server/routes/uploadBooking.js
+++ b/server/routes/uploadBooking.js
@@ -119,7 +119,14 @@ router.post('/upload-booking', upload.single("excelFile"), async function (req, 
                     [referencia]
                 );
                 const estadoExcel = (row['Estado'] ?? '').toLowerCase().trim();
-                const esCancelada = estadoExcel.startsWith('cancel');
+                const esCancelada = [
+                    'cancelled',
+                    'canceled',
+                    'cancelled_by_guest',
+                    'cancelled_by_hotel',
+                    'cancelled_by_ota',
+                    'no_show',
+                ].includes(estadoExcel);
 
                 if (existing.length > 0) {
                     if (esCancelada) {

--- a/server/routes/uploadBooking.js
+++ b/server/routes/uploadBooking.js
@@ -119,7 +119,7 @@ router.post('/upload-booking', upload.single("excelFile"), async function (req, 
                     [referencia]
                 );
                 const estadoExcel = (row['Estado'] ?? '').toLowerCase().trim();
-                const esCancelada = ['cancelled', 'cancelada', 'cancelado', 'canceled'].includes(estadoExcel);
+                const esCancelada = estadoExcel.startsWith('cancel');
 
                 if (existing.length > 0) {
                     if (esCancelada) {


### PR DESCRIPTION
## Summary

- Amplía la detección de reservas canceladas con lista explícita de estados de Booking.com: `cancelled`, `canceled`, `cancelled_by_guest`, `cancelled_by_hotel`, `cancelled_by_ota`, `no_show`
- Estado confirmado en el Excel real: `cancelled_by_guest`

Complementa #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)