### PR TITLE
[GH-117]: Sección Contabilidad, estructura base y navegación

### DIFF
--- a/front/admin-casademiranda/components/navbar/navbar.tsx
+++ b/front/admin-casademiranda/components/navbar/navbar.tsx
@@ -16,6 +16,7 @@ const NAV_LINKS = [
     { href: '/checkin-xml', label: 'Check-in XML', adminOnly: false },
     { href: '/precios-base', label: 'Precios base', adminOnly: false },
     { href: '/usuarios', label: 'Usuarios', adminOnly: true },
+    { href: '/contabilidad', label: 'Contabilidad', adminOnly: true },
 ];
 
 export default function DefaultNavbar() {

--- a/front/admin-casademiranda/pages/contabilidad/index.tsx
+++ b/front/admin-casademiranda/pages/contabilidad/index.tsx
@@ -1,0 +1,39 @@
+import "@/app/globals.css";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Tabs } from 'flowbite-react';
+import Navbar from '@/components/navbar/navbar';
+import { isAdmin } from '@/auth/auth';
+
+export default function Contabilidad() {
+    const router = useRouter();
+    const [checked, setChecked] = useState(false);
+
+    useEffect(() => {
+        if (!isAdmin()) { router.replace('/'); return; }
+        setChecked(true);
+    }, []);
+
+    if (!checked) return null;
+
+    return (
+        <>
+            <Navbar />
+            <div className="px-4 md:px-10 mt-5">
+                <h1 className="text-xl text-green text-opacity-75 font-semibold mb-5">Contabilidad</h1>
+
+                <Tabs.Group style="underline">
+                    <Tabs.Item active title="Facturas emitidas">
+                        <p className="text-sm text-gray">Próximamente</p>
+                    </Tabs.Item>
+                    <Tabs.Item title="Facturas proveedores">
+                        <p className="text-sm text-gray">Próximamente</p>
+                    </Tabs.Item>
+                    <Tabs.Item title="Informe / Gestoría">
+                        <p className="text-sm text-gray">Próximamente</p>
+                    </Tabs.Item>
+                </Tabs.Group>
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- Añade entrada "Contabilidad" en el Navbar, visible solo para usuarios con rol `admin`
- Nueva página `/contabilidad` con guard de admin (redirige a `/` si no es admin) y 3 pestañas placeholder: Facturas emitidas (#118), Facturas proveedores (#120), Informe/Gestoría (#121)

Closes #117

## Test plan
- [x] `tsc --noEmit` sin errores
- [x] `next dev` sirve `/contabilidad` (200) sin errores de compilación
- [x] Verificar en navegador con login real que un usuario no-admin no ve el enlace ni puede acceder por URL directa