### PR TITLE
[GH-135] Búsqueda por texto en selector de país

### DIFF
--- a/front/admin-casademiranda/components/clients/PaisSelector.tsx
+++ b/front/admin-casademiranda/components/clients/PaisSelector.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+import { normalize } from '@/utils/municipioSearch';
+
+type Pais = { codigo: string; pais: string };
+
+interface Props {
+    paises: Pais[];
+    value: string;
+    onChange: (codigo: string) => void;
+}
+
+export function PaisSelector({ paises, value, onChange }: Props) {
+    const [query, setQuery] = useState('');
+    const [open, setOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const p = paises.find(p => p.codigo === value);
+        setQuery(p?.pais ?? '');
+    }, [value, paises]);
+
+    const filtered = query.length >= 2
+        ? paises.filter(p => normalize(p.pais).includes(normalize(query))).slice(0, 60)
+        : [];
+
+    useEffect(() => {
+        function onClickOutside(e: MouseEvent) {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+                const p = paises.find(p => p.codigo === value);
+                setQuery(p?.pais ?? '');
+            }
+        }
+        document.addEventListener('mousedown', onClickOutside);
+        return () => document.removeEventListener('mousedown', onClickOutside);
+    }, [value, paises]);
+
+    return (
+        <div ref={containerRef} className="relative">
+            <input
+                type="text"
+                className="rounded-full w-full"
+                value={query}
+                placeholder="Buscar país..."
+                onChange={e => {
+                    setQuery(e.target.value);
+                    setOpen(true);
+                    if (!e.target.value) onChange('');
+                }}
+                onFocus={() => { if (query.length >= 2) setOpen(true); }}
+            />
+            {open && filtered.length > 0 && (
+                <ul className="absolute z-10 bg-white border border-gray-light rounded-lg mt-1 max-h-52 overflow-y-auto w-full shadow-md">
+                    {filtered.map(p => (
+                        <li
+                            key={p.codigo}
+                            className="px-3 py-1.5 text-sm text-gray-dark cursor-pointer hover:bg-gray-light"
+                            onMouseDown={() => {
+                                onChange(p.codigo);
+                                setQuery(p.pais);
+                                setOpen(false);
+                            }}
+                        >
+                            {p.pais}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/front/admin-casademiranda/pages/client/new-client.tsx
+++ b/front/admin-casademiranda/pages/client/new-client.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/router';
 import { findMunicipioByName } from '@/utils/municipioSearch';
 import { MunicipioSelector } from '@/components/clients/MunicipioSelector';
 import { PostalCodeSelector } from '@/components/clients/PostalCodeSelector';
+import { PaisSelector } from '@/components/clients/PaisSelector';
 
 type Country = {
     pais: string;
@@ -238,17 +239,11 @@ export default function NewClient() {
                         </div>
                         <div className="grid grid-cols-1">
                             <label className='rounded-full text-gray-dark text-opacity-75' id="nacionality">Nacionalidad:</label>
-                            <select
-                                className="rounded-full"
-                                id="selector-nacionality"
-                                value={nacionality || ''}
-                                onChange={(e) => setNacionality(e.target.value)}
-                            >
-                                <option value="">-- Elige un país --</option>
-                                {paises.map(p => (
-                                    <option key={p.codigo} value={p.codigo}>{p.pais}</option>
-                                ))}
-                            </select>
+                            <PaisSelector
+                                paises={paises}
+                                value={nacionality}
+                                onChange={setNacionality}
+                            />
                         </div>
 
                         <div className="grid grid-cols-1">
@@ -377,17 +372,11 @@ export default function NewClient() {
 
                         <div className="grid grid-cols-1">
                             <label className='rounded-full text-gray-dark text-opacity-75' id="country">Pais:</label>
-                            <select
-                                className="rounded-full"
-                                id="selector-country"
-                                value={country || ''}
-                                onChange={(e) => setCountry(e.target.value)}
-                            >
-                                <option value="">-- Elige un país --</option>
-                                {paises.map(p => (
-                                    <option key={p.codigo} value={p.codigo}>{p.pais}</option>
-                                ))}
-                            </select>
+                            <PaisSelector
+                                paises={paises}
+                                value={country}
+                                onChange={setCountry}
+                            />
                         </div>
                         {country === "ESP" ? (
                             <div className="grid grid-cols-1">

--- a/front/admin-casademiranda/pages/client/update-client/[id].tsx
+++ b/front/admin-casademiranda/pages/client/update-client/[id].tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { findMunicipioByName } from '@/utils/municipioSearch';
 import { MunicipioSelector } from '@/components/clients/MunicipioSelector';
 import { PostalCodeSelector } from '@/components/clients/PostalCodeSelector';
+import { PaisSelector } from '@/components/clients/PaisSelector';
 
 type Country = {
     pais: string;
@@ -204,17 +205,11 @@ export default function UpdateClient() {
 
                             <div className="grid grid-cols-1">
                                 <label className='rounded-full text-gray-dark text-opacity-75' id="nacionality">Nacionalidad:</label>
-                                <select
-                                    className="rounded-full"
-                                    id="selector-nacionality"
+                                <PaisSelector
+                                    paises={paises}
                                     value={client.nacionality || ''}
-                                    onChange={(e) => setClient({ ...client, nacionality: e.target.value })}
-                                >
-                                    <option value="">-- Elige un país --</option>
-                                    {paises.map(p => (
-                                        <option key={p.codigo} value={p.codigo}>{p.pais}</option>
-                                    ))}
-                                </select>
+                                    onChange={(codigo) => setClient({ ...client, nacionality: codigo })}
+                                />
                             </div>
                             <div className="grid grid-cols-1">
                                 <label className='text-gray-dark text-opacity-75' id="documentType">Tipo documento:</label>
@@ -333,18 +328,11 @@ export default function UpdateClient() {
 
                             <div className="grid grid-cols-1">
                                 <label className='rounded-full text-gray-dark text-opacity-75' id="country">Pais:</label>
-                                <select
-                                    className="rounded-full"
-                                    id="selector-country"
+                                <PaisSelector
+                                    paises={paises}
                                     value={client.address?.country || ''}
-                                    onChange={(e) => setClient({ ...client, address: { ...client.address, country: e.target.value } })}
-
-                                >
-                                    <option value="">-- Elige un país --</option>
-                                    {paises.map(p => (
-                                        <option key={p.codigo} value={p.codigo}>{p.pais}</option>
-                                    ))}
-                                </select>
+                                    onChange={(codigo) => setClient({ ...client, address: { ...client.address, country: codigo } })}
+                                />
                             </div>
 
                             <div className="grid grid-cols-1">


### PR DESCRIPTION
## Resumen
- Nuevo componente `PaisSelector` (mismo patrón que `MunicipioSelector`: input con filtrado por texto, dropdown con resultados, cierre al hacer click fuera).
- Sustituye los 4 `<select>` nativos de país (nacionalidad y país de dirección, en formularios de nuevo cliente y edición de cliente) por `PaisSelector`.
- Mantiene el mismo comportamiento que municipio: hace falta escribir 2+ caracteres para que aparezcan resultados.

Closes #135

## Test plan
- [ ] En "Nuevo cliente", escribir en el campo de nacionalidad y verificar que filtra países en tiempo real
- [ ] Igual para el campo "País" de la dirección
- [ ] Repetir ambas comprobaciones en "Editar cliente"
- [ ] Verificar que seleccionar un país de la lista lo guarda correctamente (submit del formulario)
- [ ] Verificar que hacer click fuera del selector cierra el dropdown y restaura el país ya seleccionado