### PR TITLE
[GH-145] Fix: postalCode NOT NULL bloquea check-in

### DIFF
--- a/infrastructure/bbdd/migrations/GH-145-address-postalcode-nullable.sql
+++ b/infrastructure/bbdd/migrations/GH-145-address-postalcode-nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE casademiranda.address
+  MODIFY COLUMN postalCode INT NULL DEFAULT NULL;

--- a/infrastructure/bbdd/schema.sql
+++ b/infrastructure/bbdd/schema.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS `casademiranda`.`address` (
   `country` VARCHAR(40) NULL DEFAULT NULL,
   `province` VARCHAR(40) NULL DEFAULT NULL,
   `location` VARCHAR(40) NULL DEFAULT NULL,
-  `postalCode` INT NOT NULL,
+  `postalCode` INT NULL DEFAULT NULL,
   PRIMARY KEY (`address_id`),
   INDEX `fk_address_idx` (`address_id` ASC))
   DEFAULT CHARACTER SET = utf8


### PR DESCRIPTION
## Resumen

`address.postalCode` era `INT NOT NULL` mientras el resto de columnas de dirección son nullable. El check-in fallaba por completo (`Error: Column 'postalCode' cannot be null`) cuando el huésped no aportaba código postal (frecuente con documentos extranjeros).

El formulario (`new-client.tsx`) ya trata este campo como opcional (no tiene `required`, a diferencia de casi todos los demás), y cuando queda vacío `parseInt('', 10)` da `NaN`, que `JSON.stringify` serializa como `null`. El problema era solo la restricción a nivel de BD.

Cambio: `postalCode` pasa a `NULL DEFAULT NULL`, igual que `line`, `country`, `province`, `location`. Actualizado también `schema.sql` para instalaciones nuevas.

No hacen falta más cambios de código: el XML de check-in al ministerio y el PDF de factura ya manejan bien un código postal vacío (`if (cliente.codigoPostalCiudad)` en `createPDF.js`).

Closes #145

## Migración BD necesaria

```sql
ALTER TABLE casademiranda.address
  MODIFY COLUMN postalCode INT NULL DEFAULT NULL;
```

## Nota aparte (no incluida en este PR)

`postalCode` es `INT`, así que los códigos postales españoles con cero inicial (ej. "08001" Barcelona) se guardan como `8001`, perdiendo el cero. Es un problema de tipo de columna preexistente, no relacionado con este bug — lo dejo aparte por si se quiere abordar en otra issue (cambiar a `VARCHAR` implicaría migrar los datos existentes).

## Test plan
- [x] Aplicar la migración en el entorno de desarrollo
- [x] Probar check-in de un huésped sin código postal (país distinto de España, campo vacío) y confirmar que se guarda correctamente