### PR TITLE
[GH-141] Eliminar foto delantera del DNI

### DIFF
--- a/front/admin-casademiranda/pages/client/new-client.tsx
+++ b/front/admin-casademiranda/pages/client/new-client.tsx
@@ -59,7 +59,6 @@ export default function NewClient() {
     const [scanning, setScanning] = useState(false);
     const [scanError, setScanError] = useState('');
     const [backFile, setBackFile] = useState<File | null>(null);
-    const [frontFile, setFrontFile] = useState<File | null>(null);
 
     const validData = (client: Client) => {
         return true;
@@ -70,7 +69,7 @@ export default function NewClient() {
         setScanning(true);
         setScanError('');
         try {
-            const result = await parseDNI(backFile, frontFile ?? undefined);
+            const result = await parseDNI(backFile);
             setName(result.nombre);
             setFistSurname(result.apellido1);
             setSecondSurname(result.apellido2);
@@ -80,7 +79,6 @@ export default function NewClient() {
             setGender(result.sex);
             setNacionality(result.nationality);
             if (result.birthDate) setBirthdate(result.birthDate);
-            if (result.expeditionDate) setExpeditionDate(result.expeditionDate);
             if (result.domicilio) setLine(result.domicilio);
             if (result.municipio) {
                 const match = findMunicipioByName(result.municipio, municipios);
@@ -92,7 +90,6 @@ export default function NewClient() {
             if (isPhotoError) {
                 setScanError('No se pudo leer el DNI. Comprueba que la foto sea nítida, el DNI ocupe casi toda la imagen y las 3 líneas de código del fondo sean visibles. Selecciona una nueva foto e inténtalo de nuevo.');
                 setBackFile(null);
-                setFrontFile(null);
             } else {
                 setScanError(err.message);
             }
@@ -210,12 +207,6 @@ export default function NewClient() {
                                 <span className="text-xs font-medium truncate">{backFile ? backFile.name : 'Seleccionar'}</span>
                                 <input type="file" accept="image/*" capture="environment" className="hidden"
                                     onChange={e => { setBackFile(e.target.files?.[0] ?? null); e.target.value = ''; }} />
-                            </label>
-                            <label className="flex-1 flex items-center gap-2 cursor-pointer rounded-lg px-3 py-2 text-sm text-gray-dark border border-gray-light hover:border-gray transition-colors">
-                                <span className="text-xs text-gray whitespace-nowrap">Cara delantera</span>
-                                <span className="text-xs font-medium truncate">{frontFile ? frontFile.name : 'Opcional'}</span>
-                                <input type="file" accept="image/*" capture="environment" className="hidden"
-                                    onChange={e => { setFrontFile(e.target.files?.[0] ?? null); e.target.value = ''; }} />
                             </label>
                         </div>
                         <div className="flex items-center gap-3">

--- a/front/admin-casademiranda/pages/client/update-client/[id].tsx
+++ b/front/admin-casademiranda/pages/client/update-client/[id].tsx
@@ -41,7 +41,6 @@ export default function UpdateClient() {
     const [scanning, setScanning] = useState(false);
     const [scanError, setScanError] = useState('');
     const [backFile, setBackFile] = useState<File | null>(null);
-    const [frontFile, setFrontFile] = useState<File | null>(null);
 
 
 
@@ -66,7 +65,7 @@ export default function UpdateClient() {
         setScanning(true);
         setScanError('');
         try {
-            const result = await parseDNI(backFile, frontFile ?? undefined);
+            const result = await parseDNI(backFile);
             setClient({
                 ...client,
                 name: result.nombre,
@@ -78,7 +77,6 @@ export default function UpdateClient() {
                 gender: result.sex,
                 nacionality: result.nationality,
                 ...(result.birthDate ? { birthdate: new Date(result.birthDate) } : {}),
-                ...(result.expeditionDate ? { expedition_date: new Date(result.expeditionDate) } : {}),
                 address: {
                     ...client.address,
                     ...(result.domicilio ? { line: result.domicilio } : {}),
@@ -91,7 +89,6 @@ export default function UpdateClient() {
             if (isPhotoError) {
                 setScanError('No se pudo leer el DNI. Comprueba que la foto sea nítida, el DNI ocupe casi toda la imagen y las 3 líneas de código del fondo sean visibles. Selecciona una nueva foto e inténtalo de nuevo.');
                 setBackFile(null);
-                setFrontFile(null);
             } else {
                 setScanError(err.message);
             }
@@ -175,12 +172,6 @@ export default function UpdateClient() {
                                     <span className="text-xs font-medium truncate">{backFile ? backFile.name : 'Seleccionar'}</span>
                                     <input type="file" accept="image/*" capture="environment" className="hidden"
                                         onChange={e => { setBackFile(e.target.files?.[0] ?? null); e.target.value = ''; }} />
-                                </label>
-                                <label className="flex-1 flex items-center gap-2 cursor-pointer rounded-lg px-3 py-2 text-sm text-gray-dark border border-gray-light hover:border-gray transition-colors">
-                                    <span className="text-xs text-gray whitespace-nowrap">Cara delantera</span>
-                                    <span className="text-xs font-medium truncate">{frontFile ? frontFile.name : 'Opcional'}</span>
-                                    <input type="file" accept="image/*" capture="environment" className="hidden"
-                                        onChange={e => { setFrontFile(e.target.files?.[0] ?? null); e.target.value = ''; }} />
                                 </label>
                             </div>
                             <div className="flex items-center gap-3">

--- a/front/admin-casademiranda/services/clients.ts
+++ b/front/admin-casademiranda/services/clients.ts
@@ -10,7 +10,6 @@ export interface DniScanResult {
     supportDocument: string;
     birthDate: string | null;
     expirationDate: string | null;
-    expeditionDate: string | null;
     sex: string;
     nationality: string;
     domicilio: string | null;
@@ -18,11 +17,10 @@ export interface DniScanResult {
     provincia: string | null;
 }
 
-export async function parseDNI(back: File, front?: File): Promise<DniScanResult> {
+export async function parseDNI(back: File): Promise<DniScanResult> {
     const token = getToken();
     const formData = new FormData();
     formData.append('back', back);
-    if (front) formData.append('front', front);
     const res = await fetch(`${API_HOST}/parse-dni`, {
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}` },

--- a/server/dni/parseDNI.js
+++ b/server/dni/parseDNI.js
@@ -40,13 +40,6 @@ function correctDateWithCheckDigit(dateStr, checkDigitChar) {
     return null;
 }
 
-function textDateToISO(text) {
-    const match = text.match(/(\d{1,2})[\s./\-](\d{1,2})[\s./\-](\d{4})/);
-    if (!match) return null;
-    const [, dd, mm, yyyy] = match;
-    return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
-}
-
 async function runOCR(imagePath, { whitelist = null, lang = 'spa' } = {}) {
     const args = [imagePath, 'stdout', '-l', lang, '--oem', '1', '--psm', '6'];
     if (whitelist) args.push('-c', `tessedit_char_whitelist=${whitelist}`);
@@ -261,35 +254,3 @@ function extractDomicilio(text) {
     return {};
 }
 
-export async function parseExpeditionDate(inputBuffer) {
-    const tmpFront    = path.join(os.tmpdir(), `dni_front_${Date.now()}.png`);
-    const tmpFront180 = path.join(os.tmpdir(), `dni_front180_${Date.now()}.png`);
-
-    try {
-        for (const [rotate180, tmpPath] of [[false, tmpFront], [true, tmpFront180]]) {
-            let pipeline = sharp(inputBuffer)
-                .rotate()
-                .greyscale().normalize().sharpen()
-                .resize({ width: 1800, withoutEnlargement: false });
-            if (rotate180) pipeline = pipeline.rotate(180);
-            await pipeline.png().toFile(tmpPath);
-
-            const text = await runOCR(tmpPath, { lang: 'spa' });
-            console.log(`[parseDNI front${rotate180 ? ' 180°' : ''}] OCR output:`, JSON.stringify(text));
-
-            const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
-            for (let i = 0; i < lines.length - 1; i++) {
-                if (/EMISI/i.test(lines[i])) {
-                    const date = textDateToISO(lines[i + 1]);
-                    console.log(`[parseDNI front${rotate180 ? ' 180°' : ''}] Expedición encontrada:`, lines[i + 1], '→', date);
-                    if (date) return date;
-                }
-            }
-        }
-
-        console.log('[parseDNI front] No se encontró fecha de expedición');
-        return null;
-    } finally {
-        [tmpFront, tmpFront180].forEach(f => { try { fs.unlinkSync(f); } catch {} });
-    }
-}

--- a/server/routes/dni.js
+++ b/server/routes/dni.js
@@ -1,20 +1,17 @@
 import express from 'express';
 import multer from 'multer';
 import { authGuard } from '../middleware/auth.js';
-import { parseDNIFromImage, parseExpeditionDate } from '../dni/parseDNI.js';
+import { parseDNIFromImage } from '../dni/parseDNI.js';
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
-router.post('/parse-dni', upload.fields([{ name: 'back', maxCount: 1 }, { name: 'front', maxCount: 1 }]), async (req, res) => {
+router.post('/parse-dni', upload.fields([{ name: 'back', maxCount: 1 }]), async (req, res) => {
     if (!authGuard(req, res)) return;
     const files = req.files ?? {};
     if (!files.back?.[0]) return res.status(400).json({ error: 'No se recibió la imagen de la cara trasera' });
     try {
         const result = await parseDNIFromImage(files.back[0].buffer);
-        if (files.front?.[0]) {
-            result.expeditionDate = await parseExpeditionDate(files.front[0].buffer);
-        }
         res.json(result);
     } catch (err) {
         console.error('Error parsing DNI:', err.message);


### PR DESCRIPTION
## Resumen

La fecha de expedición del DNI dejó de ser obligatoria (#136/GH-136), y era el único dato que se extraía de la foto de la cara delantera (via OCR). Al no ser ya necesaria, se elimina esa foto del flujo de alta/edición de cliente.

- Se quita el input de "Cara delantera" (opcional) en `new-client.tsx` y `update-client/[id].tsx`.
- `POST /parse-dni` deja de aceptar el fichero `front`.
- Se elimina `parseExpeditionDate` (y `textDateToISO`) de `parseDNI.js`, código muerto tras el cambio.
- El campo "Fecha de expedición" se mantiene en el formulario, pero ahora solo se rellena a mano.

Closes #141

## Test plan
- [x] `tsc --noEmit` sin errores
- [x] `node --check` limpio en el backend modificado
- [ ] Probar alta de cliente escaneando solo la cara trasera del DNI y confirmar que se rellenan bien los datos (sin campo de foto delantera)