### PR TITLE
[GH-143] Fix: error al enviar factura por email

### DIFF
--- a/infrastructure/compose.yaml
+++ b/infrastructure/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql
+    image: mysql:8.0.33
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password

--- a/server/pdf/createPDF.js
+++ b/server/pdf/createPDF.js
@@ -189,6 +189,7 @@ function buildPDF(reserva, cliente) {
 
 export async function generarFactura(reserva, cliente) {
     const buffer = await buildPDF(reserva, cliente);
+    fs.mkdirSync('./facturas-cliente', { recursive: true });
     fs.writeFileSync('./facturas-cliente/' + reserva.numeroFactura + '.pdf', buffer);
 }
 


### PR DESCRIPTION
## Resumen

En producción (Raspberry Pi) fallaba el envío de la factura por email. `generarFactura` escribía el PDF en `./facturas-cliente/` sin asegurarse antes de que el directorio existiera; si no existía (p.ej. tras un rebuild sin la carpeta creada aún), `fs.writeFileSync` fallaba con ENOENT y el envío nunca llegaba a ejecutarse.

- `generarFactura` crea el directorio con `fs.mkdirSync(..., { recursive: true })` antes de escribir (mismo patrón que ya usamos para `facturas-proveedor`).
- Se fija la versión de la imagen de MySQL (`mysql:8.0.33`) en `compose.yaml` para evitar drift de versión en local.

Closes #143

## Test plan
- [x] `node --check` sin errores en `createPDF.js`
- [ ] Probar generación y envío de factura desde una instalación limpia (sin la carpeta `facturas-cliente` creada de antemano) y confirmar que ya no falla