### PR TITLE
hotfix: revertir pin de version de mysql

### DIFF
--- a/infrastructure/compose.yaml
+++ b/infrastructure/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:8.0.33
+    image: mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
image: mysql:8.0.33 (añadido en el fix de GH-143) provoca que MySQL se niegue a arrancar en produccion: el datadir de la Raspberry ya estaba inicializado por una version mas reciente (9.5.0), y InnoDB no permite downgrade de version de datadir. Se revierte a "image: mysql" (latest), que es lo que ya tenia esa version funcionando. No se ha perdido ningun dato, el datadir en ./bbdd/data no se toca.