### PR TITLE
[GH-157]: no enviar factura al cliente por defecto

### DIFF
--- a/front/admin-casademiranda/interfaces/bill.ts
+++ b/front/admin-casademiranda/interfaces/bill.ts
@@ -12,6 +12,7 @@ export type Bill = {
   apellidos: string
   dni: string
   email: string
+  enviarACliente?: boolean
   // empresa only
   nombreEmpresa?: string
   codigoPostalCiudad?: string

--- a/front/admin-casademiranda/pages/booking/[id].tsx
+++ b/front/admin-casademiranda/pages/booking/[id].tsx
@@ -106,6 +106,7 @@ export default function BookingPage() {
     const [billConcepto, setBillConcepto] = useState('');
     const [billExtras, setBillExtras] = useState<BillExtra[]>([]);
     const [billEmail, setBillEmail] = useState('');
+    const [billEnviarACliente, setBillEnviarACliente] = useState(false);
     const [billNombreEmpresa, setBillNombreEmpresa] = useState('');
     const [billCodigoPostalCiudad, setBillCodigoPostalCiudad] = useState('');
     const [billPais, setBillPais] = useState('España');
@@ -157,6 +158,7 @@ export default function BookingPage() {
         const totalCenas = cenas.reduce((sum, c) => sum + Number(c.price) * c.quantity, 0);
         setBillExtras(totalCenas > 0 ? [{ descripcion: 'Cenas', precio: Math.round(totalCenas * 100) / 100 }] : []);
         setBillEmail(clients?.[0]?.email ?? '');
+        setBillEnviarACliente(false);
         setBillNombreEmpresa('');
         setBillCodigoPostalCiudad('');
         setBillPais('España');
@@ -185,6 +187,7 @@ export default function BookingPage() {
             apellidos: billSurname,
             dni: billDni,
             email: billEmail,
+            enviarACliente: billEnviarACliente,
             nombreEmpresa: billTipo === 'empresa' ? billNombreEmpresa || undefined : undefined,
             codigoPostalCiudad: billTipo === 'empresa' ? billCodigoPostalCiudad || undefined : undefined,
             pais: billTipo === 'empresa' ? billPais || undefined : undefined,
@@ -625,7 +628,19 @@ export default function BookingPage() {
                                         <div className="sm:col-span-2">
                                             <label className={labelClass}>Email destinatario</label>
                                             <input className={inputClass} type="email" value={billEmail} onChange={e => setBillEmail(e.target.value)} placeholder="email@ejemplo.com" />
-                                            <p className="text-xs text-gray mt-1">casademirandaezaro@gmail.com recibirá siempre una copia (CC)</p>
+                                            <label className="flex items-center gap-2 mt-2 text-xs text-gray-dark">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={billEnviarACliente}
+                                                    onChange={e => setBillEnviarACliente(e.target.checked)}
+                                                />
+                                                Enviar también al cliente
+                                            </label>
+                                            <p className="text-xs text-gray mt-1">
+                                                {billEnviarACliente
+                                                    ? 'Se enviará al cliente con copia (CC) a casademirandaezaro@gmail.com'
+                                                    : 'Se enviará solo a casademirandaezaro@gmail.com'}
+                                            </p>
                                         </div>
                                         <div className="sm:col-span-2">
                                             <label className={labelClass}>Concepto (opcional)</label>

--- a/server/mail/sendMail.js
+++ b/server/mail/sendMail.js
@@ -2,7 +2,9 @@ import nodemailer from 'nodemailer';
 import readProperty from '../configuration/readConfiguration.js';
 
 
-const sendMail = (idBooking, name, surname, email) => {
+const CASA_MIRANDA_EMAIL = "casademirandaezaro@gmail.com";
+
+const sendMail = (idBooking, name, surname, email, enviarACliente = false) => {
     console.log("Send mail for booking: ", idBooking);
 
     const pass = readProperty("mail.facturacion.password");
@@ -22,10 +24,13 @@ const sendMail = (idBooking, name, surname, email) => {
         }
     });
 
+    const mailOptions = enviarACliente
+        ? { to: email, cc: CASA_MIRANDA_EMAIL }
+        : { to: CASA_MIRANDA_EMAIL };
+
     transporter.sendMail({
         from: '"Facturacion Casa de Miranda" <facturacion@casademiranda.com>',
-        to: email,
-        cc: "casademirandaezaro@gmail.com",
+        ...mailOptions,
         subject: "Factura " + idBooking,
         html: bodyHtml,
         attachments: [

--- a/server/routes/facturas.js
+++ b/server/routes/facturas.js
@@ -61,7 +61,7 @@ router.post('/factura', async function (req, res) {
 
     const { reserva, cliente } = parseBillBody(req.body);
     await generarFactura(reserva, cliente);
-    sendMail(reserva.numeroFactura, cliente.nombre, cliente.apellidos, cliente.email);
+    sendMail(reserva.numeroFactura, cliente.nombre, cliente.apellidos, cliente.email, req.body.enviarACliente === true);
     res.send('Datos recibidos correctamente.');
 });
 


### PR DESCRIPTION
## Summary
- Por defecto, al generar una factura ya no se envía al cliente: se envía solo a casademirandaezaro@gmail.com.
- Se añade checkbox "Enviar también al cliente" en el modal de facturación; si se marca, se envía al cliente con copia (CC) a casademirandaezaro@gmail.com.

Closes #157

## Test plan
- [x] Generar factura sin marcar el checkbox → llega solo a casademirandaezaro@gmail.com
- [x] Generar factura marcando "Enviar también al cliente" → llega al cliente con copia a casademirandaezaro@gmail.com