### PR TITLE
[GH-156]: eliminar campo fecha de expedición de las vistas del frontal

### DIFF
--- a/front/admin-casademiranda/components/clients/clientComponent.tsx
+++ b/front/admin-casademiranda/components/clients/clientComponent.tsx
@@ -73,7 +73,6 @@ export default function ClientComponent({ client }: ClientProps) {
                 <Field label="Tipo documento" value={client.document_type} />
                 <Field label="Número documento" value={client.document_number} />
                 <Field label="Soporte documento" value={client.support_document} />
-                <DateComponent label="Fecha expedición" date={client.expedition_date} />
             </div>
 
             {/* Contacto */}

--- a/front/admin-casademiranda/interfaces/client.ts
+++ b/front/admin-casademiranda/interfaces/client.ts
@@ -5,7 +5,7 @@ export type Client = {
     document_type: string
     document_number: string
     support_document: string
-    expedition_date: Date
+    expedition_date?: Date
     name: string
     firstSurname: string
     secondSurname: string

--- a/front/admin-casademiranda/pages/client/new-client.tsx
+++ b/front/admin-casademiranda/pages/client/new-client.tsx
@@ -31,7 +31,6 @@ export default function NewClient() {
     const [nacionality, setNacionality] = useState("");
     const [documentType, setDocumentType] = useState("");
     const [documentNumber, setDocumentNumber] = useState("");
-    const [expeditionDate, setExpeditionDate] = useState("");
     const [name, setName] = useState("");
     const [firstSurname, setFistSurname] = useState("");
     const [secondSurname, setSecondSurname] = useState("");
@@ -125,7 +124,6 @@ export default function NewClient() {
             document_type: documentType,
             document_number: documentNumber,
             support_document: supportDocument,
-            expedition_date: new Date(expeditionDate),
             name: name,
             firstSurname: firstSurname,
             secondSurname: secondSurname,
@@ -256,11 +254,6 @@ export default function NewClient() {
                         <div className="grid grid-cols-1">
                             <label className='text-gray-dark text-opacity-75' id="supportDocument">Soporte documento:</label>
                             <input type="text" className='rounded-full' id="supportDocument" name="supportDocument" value={supportDocument} onChange={(e) => setSupportDocument(e.target.value)} />
-                        </div>
-
-                        <div className="grid grid-cols-1">
-                            <label className='text-gray-dark text-opacity-75' id="expeditionDate">Fecha de expedición:</label>
-                            <input type="date" className='rounded-full' id="expeditionDate" name="expeditionDate" value={expeditionDate} onChange={(e) => setExpeditionDate(e.target.value)} />
                         </div>
 
                         <div className="grid grid-cols-1">

--- a/front/admin-casademiranda/pages/client/update-client/[id].tsx
+++ b/front/admin-casademiranda/pages/client/update-client/[id].tsx
@@ -221,10 +221,6 @@ export default function UpdateClient() {
                                 <input className='rounded-full' type="text" id="supportDocument" name="supportDocument" value={client.support_document} onChange={(e) => setClient({ ...client, support_document: e.target.value })} />
                             </div>
                             <div className="grid grid-cols-1">
-                                <label className='text-gray-dark text-opacity-75' id="expeditionDate">Fecha de expedición:</label>
-                                <input className='rounded-full' type="date" id="expeditionDate" name="expeditionDate" value={client.expedition_date ? new Date(client.expedition_date).toISOString().split('T')[0] : ""} onChange={(e) => setClient({ ...client, expedition_date: new Date(e.target.value) })} />
-                            </div>
-                            <div className="grid grid-cols-1">
                                 <label className='text-gray-dark text-opacity-75' id="nombre">Nombre:</label>
                                 <input className='rounded-full' type="text" id="nombre" name="nombre" value={client.name} onChange={(e) => setClient({ ...client, name: e.target.value })} required />
                             </div>


### PR DESCRIPTION
## Summary
- Se elimina el campo "Fecha de expedición" de las vistas del frontal admin: alta de cliente, edición de cliente y ficha de cliente.
- El campo `expedition_date` pasa a opcional en la interfaz `Client` del frontend.
- No se toca backend, base de datos ni el DTO (`ClientDTO`), el dato puede seguir siendo relevante para otros flujos (p.ej. check-in ministerio).

Closes #156

## Test plan
- [x] Alta de cliente: ya no aparece el campo "Fecha de expedición" y el alta funciona correctamente
- [x] Edición de cliente: ya no aparece el campo, guardar cambios funciona correctamente
- [x] Ficha de cliente (vista de solo lectura): ya no se muestra "Fecha expedición"