### PR TITLE
[GH-162]: incluir segundo apellido al prellenar la factura

### DIFF
--- a/front/admin-casademiranda/interfaces/booking.ts
+++ b/front/admin-casademiranda/interfaces/booking.ts
@@ -5,6 +5,7 @@ export type Booking = {
     confirmation_number: string
     name: string
     surname: string
+    surname2: string | null
     identifier: string
     check_in: Date
     check_out: Date

--- a/front/admin-casademiranda/pages/booking/[id].tsx
+++ b/front/admin-casademiranda/pages/booking/[id].tsx
@@ -150,7 +150,7 @@ export default function BookingPage() {
         if (!booking) return;
         setBillTipo('personal');
         setBillName(booking.name);
-        setBillSurname(booking.surname);
+        setBillSurname([booking.surname, booking.surname2].filter(Boolean).join(' '));
         setBillDni(booking.identifier);
         setBillAddress('');
         setBillConcepto('');

--- a/server/bookings/listBooking.js
+++ b/server/bookings/listBooking.js
@@ -2,7 +2,7 @@ import executeQuery from '../sql/sqlUtils.js';
 
 
 const listAllBookings = async (limit) => {
-    const query = "SELECT b.booking_id, booking_date, check_in, check_out, state, payment_type, confirmation_number, other_platform_reference, b.notes, c.name, surname, identifier, r.name as room, br.price, number_bed as extra_beds, brex.price_bed FROM bookings b INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking=1 INNER JOIN booking_room br ON br.booking_id = b.booking_id INNER JOIN rooms r ON br.room_id = r.room_id LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id=br.booking_room_id ORDER BY check_in ASC;";
+    const query = "SELECT b.booking_id, booking_date, check_in, check_out, state, payment_type, confirmation_number, other_platform_reference, b.notes, c.name, surname, c.surname2, identifier, r.name as room, br.price, number_bed as extra_beds, brex.price_bed FROM bookings b INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking=1 INNER JOIN booking_room br ON br.booking_id = b.booking_id INNER JOIN rooms r ON br.room_id = r.room_id LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id=br.booking_room_id ORDER BY check_in ASC;";
     return new Promise((resolve, reject) => {
         executeQuery(query).then((result, error) => {
             if (error) reject(error);
@@ -13,7 +13,7 @@ const listAllBookings = async (limit) => {
 
 const listBookingById = async (identifier) => {
     return new Promise((resolve, reject) => {
-        executeQuery('SELECT b.booking_id, booking_date, check_in, check_out, state, payment_type, confirmation_number, other_platform_reference, b.notes, c.name, surname, identifier, r.name as room, br.price, number_bed as extra_beds, brex.price_bed FROM bookings b INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking=1 INNER JOIN booking_room br ON br.booking_id = b.booking_id INNER JOIN rooms r ON br.room_id = r.room_id LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id=br.booking_room_id WHERE b.booking_id=? ORDER BY check_in ASC', [identifier]).then((result, error) => {
+        executeQuery('SELECT b.booking_id, booking_date, check_in, check_out, state, payment_type, confirmation_number, other_platform_reference, b.notes, c.name, surname, c.surname2, identifier, r.name as room, br.price, number_bed as extra_beds, brex.price_bed FROM bookings b INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking=1 INNER JOIN booking_room br ON br.booking_id = b.booking_id INNER JOIN rooms r ON br.room_id = r.room_id LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id=br.booking_room_id WHERE b.booking_id=? ORDER BY check_in ASC', [identifier]).then((result, error) => {
             if (error) reject(error);
             resolve(processBooking(result))
         })
@@ -24,7 +24,7 @@ const listBookingById = async (identifier) => {
 
 const listBookingByCustomer = async (identifier) => {
     return new Promise((resolve, reject) => {
-        executeQuery('SELECT b.booking_id, booking_date, check_in, check_out, state, payment_type, confirmation_number, other_platform_reference, b.notes, c.name, surname, identifier, r.name as room, br.price, number_bed as extra_beds, brex.price_bed FROM bookings b INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking=1 INNER JOIN booking_room br ON br.booking_id = b.booking_id INNER JOIN rooms r ON br.room_id = r.room_id LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id=br.booking_room_id WHERE c.identifier=? ORDER BY check_in ASC', [identifier]).then((result, error) => {
+        executeQuery('SELECT b.booking_id, booking_date, check_in, check_out, state, payment_type, confirmation_number, other_platform_reference, b.notes, c.name, surname, c.surname2, identifier, r.name as room, br.price, number_bed as extra_beds, brex.price_bed FROM bookings b INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking=1 INNER JOIN booking_room br ON br.booking_id = b.booking_id INNER JOIN rooms r ON br.room_id = r.room_id LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id=br.booking_room_id WHERE c.identifier=? ORDER BY check_in ASC', [identifier]).then((result, error) => {
             if (error) reject(error);
             resolve(processBookings(result))
         })
@@ -50,6 +50,7 @@ const processBooking = (bookings) => {
                 notes: bookings[i].notes ?? null,
                 name: bookings[i].name,
                 surname: bookings[i].surname,
+                surname2: bookings[i].surname2 ?? null,
                 identifier: bookings[i].identifier,
                 rooms: [{
                     name: bookings[i].room,
@@ -97,6 +98,7 @@ const processBookings = (bookings) => {
                 notes: bookings[i].notes ?? null,
                 name: bookings[i].name,
                 surname: bookings[i].surname,
+                surname2: bookings[i].surname2 ?? null,
                 identifier: bookings[i].identifier,
                 rooms: [{
                     name: bookings[i].room,


### PR DESCRIPTION
## Summary
- `listBooking.js` no seleccionaba `customers.surname2` en ninguna de sus 3 queries, así que el objeto `booking` (usado para prellenar el modal de facturación) solo traía el primer apellido aunque el cliente tuviera los dos apellidos guardados.
- Se añade `surname2` a la query, al mapeo de resultado y al interface `Booking`.
- El campo "Apellidos" del modal de factura ahora se prellena con `surname + surname2` concatenados (sigue siendo editable manualmente).

Closes #162

Nota: hay otros sitios (listado de reservas, ficha de reserva, check-in, editar reserva) que también muestran solo `booking.surname` — mismo patrón, pero fuera del alcance de este issue, que es específico de facturas.

## Test plan
- [x] Crear/editar un cliente con dos apellidos, hacer la reserva y generar la factura → el campo "Apellidos" del modal aparece con ambos apellidos
- [x] Cliente con un solo apellido → sigue funcionando igual (sin espacio extra al final)