### PR TITLE
[GH-142]: cifrar contraseñas de configuración con AES-256-GCM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /infrastructure/launch-docker.exe
 /server/node_modules
 /server/configuration/password.json
+/server/configuration/password.json.bak
 /server/password.txt
 /server/confmail.PNG
 /infrastructure/bbdd/data

--- a/infrastructure/compose.yaml
+++ b/infrastructure/compose.yaml
@@ -12,10 +12,12 @@ services:
       - node-network
   
   backend:
-    build: 
+    build:
       context: ../server
-    networks: 
+    networks:
       - node-network
+    environment:
+      - CONFIG_MASTER_KEY=${CONFIG_MASTER_KEY}
     volumes:
       - /project/node_modules
       - ./certs:/infrastructure/certs

--- a/server/configuration/encryptSecrets.js
+++ b/server/configuration/encryptSecrets.js
@@ -1,0 +1,32 @@
+// Uso: CONFIG_MASTER_KEY=<64 hex chars> node configuration/encryptSecrets.js
+//
+// Cifra en el sitio las claves sensibles (password/secretKey) de password.json.
+// Genera antes password.json.bak con el contenido original.
+// Genera una clave nueva con: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+
+import fs from 'fs';
+import { encryptValue, isEncrypted } from './secretsCrypto.js';
+
+const CONFIG_PATH = './configuration/password.json';
+const SENSITIVE_KEY_PATTERN = /password|secretKey/i;
+
+const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+const encryptedKeys = [];
+for (const [key, value] of Object.entries(config)) {
+    if (SENSITIVE_KEY_PATTERN.test(key) && typeof value === 'string' && value !== '' && !isEncrypted(value)) {
+        config[key] = encryptValue(value);
+        encryptedKeys.push(key);
+    }
+}
+
+if (encryptedKeys.length === 0) {
+    console.log('Nada que cifrar: no hay claves sensibles en texto plano.');
+    process.exit(0);
+}
+
+fs.copyFileSync(CONFIG_PATH, CONFIG_PATH + '.bak');
+fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 4) + '\n');
+
+console.log('Claves cifradas:', encryptedKeys.join(', '));
+console.log('Copia de seguridad guardada en', CONFIG_PATH + '.bak');

--- a/server/configuration/readConfiguration.js
+++ b/server/configuration/readConfiguration.js
@@ -1,11 +1,12 @@
 import fs from 'fs';
+import { resolveSecret } from './secretsCrypto.js';
 
 const readProperty = (property) => {
 
     const configPassword = JSON.parse(fs.readFileSync('./configuration/password.json', 'utf8'));
 
     if (configPassword.hasOwnProperty(property)){
-        return configPassword[property];
+        return resolveSecret(configPassword[property]);
     }
 
     const genericConfig = JSON.parse(fs.readFileSync('./configuration/configuration.json', 'utf8'));

--- a/server/configuration/secretsCrypto.js
+++ b/server/configuration/secretsCrypto.js
@@ -1,0 +1,44 @@
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const ENC_PREFIX = 'enc:';
+
+const getMasterKey = () => {
+    const keyHex = process.env.CONFIG_MASTER_KEY;
+    if (!keyHex) {
+        throw new Error('CONFIG_MASTER_KEY no está definida. Exporta una clave de 32 bytes en hexadecimal (64 caracteres) antes de arrancar el servidor.');
+    }
+    const key = Buffer.from(keyHex, 'hex');
+    if (key.length !== 32) {
+        throw new Error('CONFIG_MASTER_KEY debe ser una cadena hexadecimal de 64 caracteres (32 bytes).');
+    }
+    return key;
+};
+
+const isEncrypted = (value) => typeof value === 'string' && value.startsWith(ENC_PREFIX);
+
+const encryptValue = (plainText) => {
+    const key = getMasterKey();
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+    const ciphertext = Buffer.concat([cipher.update(plainText, 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    return ENC_PREFIX + [iv, authTag, ciphertext].map(buf => buf.toString('hex')).join(':');
+};
+
+const decryptValue = (encoded) => {
+    const key = getMasterKey();
+    const [ivHex, authTagHex, cipherHex] = encoded.slice(ENC_PREFIX.length).split(':');
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const ciphertext = Buffer.from(cipherHex, 'hex');
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    const plainText = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return plainText.toString('utf8');
+};
+
+const resolveSecret = (value) => (isEncrypted(value) ? decryptValue(value) : value);
+
+export { encryptValue, decryptValue, resolveSecret, isEncrypted };


### PR DESCRIPTION
## Resumen
- Las contraseñas de usuario de la app ya usaban bcrypt (desde GH-19), esto no cambia.
- El fichero `server/configuration/password.json` (BD, email, JWT secret) guardaba sus valores en texto plano en disco. Como el servidor necesita el valor real para autenticarse contra MySQL/SMTP/IMAP, no se puede hashear (irreversible); se cifra con **AES-256-GCM** usando una clave maestra en la variable de entorno `CONFIG_MASTER_KEY` (no forma parte del repo).
- `readConfiguration.js` descifra de forma transparente los valores que empiezan por `enc:`, y sigue devolviendo tal cual los valores en texto plano — permite migrar sin romper despliegues existentes.
- `encryptSecrets.js` es un script de migración: cifra en el sitio las claves sensibles (`password`, `secretKey`) de `password.json`, dejando un backup `.bak` (añadido a `.gitignore`).

## Cómo desplegar este cambio
1. Generar una clave: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
2. Definir `CONFIG_MASTER_KEY` con esa clave donde corra el backend (Raspberry Pi), fuera del repo.
3. Ejecutar `CONFIG_MASTER_KEY=<clave> node configuration/encryptSecrets.js` dentro de `server/` para cifrar `password.json` en el sitio.
4. Reiniciar el backend.

## Test plan
- [x] Round-trip encrypt/decrypt con clave de prueba
- [x] `encryptSecrets.js` sobre un `password.json` de prueba: cifra solo las claves sensibles y deja backup
- [x] `readProperty` descifra un valor cifrado de prueba correctamente
- [ ] Ejecutar la migración real en la Raspberry Pi con `CONFIG_MASTER_KEY` propia y verificar que el backend arranca (pendiente, requiere acceso al servidor)

Cierra #142