### PR TITLE
[GH-167]: parametrizar contraseña root de MySQL vía .env

### DIFF
--- a/infrastructure/compose.yaml
+++ b/infrastructure/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: mysql
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
       - 3306:3306
     volumes:


### PR DESCRIPTION
## Resumen
`infrastructure/compose.yaml` tenía `MYSQL_ROOT_PASSWORD: password` hardcodeada en texto plano. Se cambia a `${MYSQL_ROOT_PASSWORD}`, leída de `infrastructure/.env` (mismo patrón ya usado para `CONFIG_MASTER_KEY` en #142).

No se toca `infrastructure/bbdd/docker-compose.yml` (compose aparte, solo para levantar una BD local desechable en desarrollo).

## Importante: esto NO rota la contraseña real por sí solo
`MYSQL_ROOT_PASSWORD` solo la usa la imagen oficial de MySQL para fijar la contraseña de root **al inicializar un volumen de datos vacío**. La Pi ya tiene datos reales en `./bbdd/data`, así que este cambio de código no cambia nada hasta que además:

1. Se defina `MYSQL_ROOT_PASSWORD=<contraseña fuerte>` en `infrastructure/.env` de la Pi.
2. Se rote la contraseña del MySQL ya corriendo con `ALTER USER` (o `mysqladmin`), a mano, contra la instancia en vivo.
3. Se actualice `sql.password` en `server/configuration/password.json` con el mismo valor (y se vuelva a cifrar con `encryptSecrets.js`, ver #142).
4. Se reinicie el backend.

Esos pasos manuales quedan pendientes de coordinar antes de aplicarlos en producción, por el riesgo de tocar la BD en vivo.

## Test plan
- [x] Compose sigue siendo YAML válido
- [ ] Rotación real en la Raspberry Pi (pendiente, coordinar aparte)

Relacionado con #142. Cierra #167