### PR TITLE
[GH-118]: recuperar Facturas emitidas perdida en merge de GH-120

### DIFF
--- a/front/admin-casademiranda/components/contabilidad/facturas-emitidas.tsx
+++ b/front/admin-casademiranda/components/contabilidad/facturas-emitidas.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import { listInvoices, viewInvoicePdf, resendInvoice } from '@/services/invoices';
+import type { Invoice } from '@/interfaces/invoice';
+
+const inputClass = "mt-1 w-full border border-gray-light rounded-lg px-3 py-2 text-gray-dark text-sm focus:outline-none focus:border-gray";
+const labelClass = "text-xs text-gray uppercase tracking-wide block";
+
+const currentYear = new Date().getFullYear();
+const YEARS = Array.from({ length: 5 }, (_, i) => currentYear - i);
+const QUARTERS = [1, 2, 3, 4];
+
+function currentQuarter() {
+    return Math.ceil((new Date().getMonth() + 1) / 3);
+}
+
+export default function FacturasEmitidas() {
+    const [year, setYear] = useState(currentYear);
+    const [quarter, setQuarter] = useState(currentQuarter());
+    const [invoices, setInvoices] = useState<Invoice[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [resendingId, setResendingId] = useState<string | null>(null);
+
+    useEffect(() => { load(); }, [year, quarter]);
+
+    async function load() {
+        setLoading(true);
+        setError('');
+        try {
+            setInvoices(await listInvoices(year, quarter));
+        } catch (e: any) {
+            setError(e.message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function handleView(confirmationNumber: string) {
+        try {
+            const blob = await viewInvoicePdf(confirmationNumber);
+            window.open(URL.createObjectURL(blob), '_blank');
+        } catch (e: any) {
+            alert(`Error: ${e.message}`);
+        }
+    }
+
+    async function handleResend(confirmationNumber: string) {
+        if (!confirm(`¿Reenviar la factura ${confirmationNumber} por email?`)) return;
+        setResendingId(confirmationNumber);
+        try {
+            await resendInvoice(confirmationNumber);
+            alert('Factura reenviada.');
+        } catch (e: any) {
+            alert(`Error: ${e.message}`);
+        } finally {
+            setResendingId(null);
+        }
+    }
+
+    const total = invoices.reduce((sum, i) => sum + i.total, 0);
+
+    return (
+        <div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4 max-w-lg">
+                <div>
+                    <label className={labelClass}>Año</label>
+                    <select className={inputClass} value={year} onChange={e => setYear(Number(e.target.value))}>
+                        {YEARS.map(y => <option key={y} value={y}>{y}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className={labelClass}>Trimestre</label>
+                    <select className={inputClass} value={quarter} onChange={e => setQuarter(Number(e.target.value))}>
+                        {QUARTERS.map(q => <option key={q} value={q}>T{q}</option>)}
+                    </select>
+                </div>
+            </div>
+
+            {loading ? (
+                <p className="text-sm text-gray">Cargando...</p>
+            ) : error ? (
+                <p className="text-sm text-orange">{error}</p>
+            ) : (
+                <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="border-b border-gray-light">
+                                <th className="text-left py-2 px-3 text-xs text-gray uppercase tracking-wide font-semibold">Nº Factura</th>
+                                <th className="text-left py-2 px-3 text-xs text-gray uppercase tracking-wide font-semibold">Huésped</th>
+                                <th className="text-left py-2 px-3 text-xs text-gray uppercase tracking-wide font-semibold">Fecha checkout</th>
+                                <th className="text-right py-2 px-3 text-xs text-gray uppercase tracking-wide font-semibold">Total</th>
+                                <th className="py-2 px-3"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {invoices.map(inv => (
+                                <tr key={inv.confirmationNumber} className="border-b border-gray-light last:border-0">
+                                    <td className="py-2 px-3 text-gray-dark font-medium">{inv.confirmationNumber}</td>
+                                    <td className="py-2 px-3">{inv.guest}</td>
+                                    <td className="py-2 px-3">{new Date(inv.checkOut).toLocaleDateString('es-ES')}</td>
+                                    <td className="py-2 px-3 text-right">{inv.total.toFixed(2)} €</td>
+                                    <td className="py-2 px-3 text-right whitespace-nowrap">
+                                        <button onClick={() => handleView(inv.confirmationNumber)}
+                                            className="text-gray hover:text-gray-dark transition-colors text-xs font-semibold mr-3">
+                                            Ver PDF
+                                        </button>
+                                        <button onClick={() => handleResend(inv.confirmationNumber)}
+                                            disabled={resendingId === inv.confirmationNumber}
+                                            className="text-gray hover:text-green transition-colors text-xs font-semibold disabled:opacity-40">
+                                            {resendingId === inv.confirmationNumber ? 'Enviando...' : 'Reenviar email'}
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                            {invoices.length === 0 && (
+                                <tr><td colSpan={5} className="py-4 px-3 text-center text-gray text-sm">Sin facturas en este periodo</td></tr>
+                            )}
+                        </tbody>
+                        {invoices.length > 0 && (
+                            <tfoot>
+                                <tr>
+                                    <td colSpan={3} className="py-2 px-3 text-right text-xs text-gray uppercase tracking-wide font-semibold">Total periodo</td>
+                                    <td className="py-2 px-3 text-right font-semibold text-gray-dark">{total.toFixed(2)} €</td>
+                                    <td></td>
+                                </tr>
+                            </tfoot>
+                        )}
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/front/admin-casademiranda/interfaces/invoice.ts
+++ b/front/admin-casademiranda/interfaces/invoice.ts
@@ -1,0 +1,6 @@
+export interface Invoice {
+    confirmationNumber: string;
+    guest: string;
+    checkOut: string;
+    total: number;
+}

--- a/front/admin-casademiranda/pages/contabilidad/index.tsx
+++ b/front/admin-casademiranda/pages/contabilidad/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Tabs } from 'flowbite-react';
 import Navbar from '@/components/navbar/navbar';
+import FacturasEmitidas from '@/components/contabilidad/facturas-emitidas';
 import FacturasProveedores from '@/components/contabilidad/facturas-proveedores';
 import { isAdmin } from '@/auth/auth';
 
@@ -25,7 +26,7 @@ export default function Contabilidad() {
 
                 <Tabs.Group style="underline">
                     <Tabs.Item active title="Facturas emitidas">
-                        <p className="text-sm text-gray">Próximamente</p>
+                        <FacturasEmitidas />
                     </Tabs.Item>
                     <Tabs.Item title="Facturas proveedores">
                         <FacturasProveedores />

--- a/front/admin-casademiranda/services/invoices.ts
+++ b/front/admin-casademiranda/services/invoices.ts
@@ -1,0 +1,32 @@
+import type { Invoice } from '../interfaces/invoice';
+import { getToken } from '../auth/auth';
+import { API_HOST } from './config';
+
+const API_URL = `${API_HOST}/factura`;
+
+export async function listInvoices(year: number, quarter: number): Promise<Invoice[]> {
+    const token = getToken();
+    const response = await fetch(`${API_URL}/list?year=${year}&quarter=${quarter}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!response.ok) throw new Error(`Error HTTP ${response.status}`);
+    return response.json();
+}
+
+export async function viewInvoicePdf(confirmationNumber: string): Promise<Blob> {
+    const token = getToken();
+    const response = await fetch(`${API_URL}/${confirmationNumber}/pdf`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!response.ok) throw new Error(`Error HTTP ${response.status}`);
+    return response.blob();
+}
+
+export async function resendInvoice(confirmationNumber: string): Promise<void> {
+    const token = getToken();
+    const response = await fetch(`${API_URL}/${confirmationNumber}/resend`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!response.ok) throw new Error(`Error HTTP ${response.status}`);
+}

--- a/server/invoices/listInvoices.js
+++ b/server/invoices/listInvoices.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import executeQuery from '../sql/sqlUtils.js';
+
+const FACTURAS_DIR = './facturas-cliente';
+const FILENAME_RE = /^(\d{4})(\d{2})(\d{2})\d{3}\.pdf$/;
+
+function quarterOf(month) {
+    return Math.ceil(month / 3);
+}
+
+const listInvoices = async (year, quarter) => {
+    const files = fs.readdirSync(FACTURAS_DIR);
+    const matched = [];
+    for (const file of files) {
+        const match = file.match(FILENAME_RE);
+        if (!match) continue;
+        const [, fileYear, fileMonth] = match;
+        if (year && Number(fileYear) !== Number(year)) continue;
+        if (quarter && quarterOf(Number(fileMonth)) !== Number(quarter)) continue;
+        matched.push(file.replace('.pdf', ''));
+    }
+
+    if (matched.length === 0) return [];
+
+    const rows = await executeQuery(
+        `SELECT b.confirmation_number, b.check_out, c.name, c.surname, br.price, brex.price_bed
+         FROM bookings b
+         INNER JOIN booking_customer bc ON b.booking_id = bc.booking_id
+         INNER JOIN customers c ON bc.customer_id = c.customer_id AND c.made_booking = 1
+         INNER JOIN booking_room br ON br.booking_id = b.booking_id
+         LEFT JOIN booking_room_extra_bed brex ON brex.booking_room_id = br.booking_room_id
+         WHERE b.confirmation_number IN (?)`,
+        [matched]
+    );
+
+    const invoices = new Map();
+    for (const row of rows ?? []) {
+        let invoice = invoices.get(row.confirmation_number);
+        if (!invoice) {
+            invoice = {
+                confirmationNumber: row.confirmation_number,
+                guest: `${row.name} ${row.surname}`,
+                checkOut: row.check_out,
+                total: 0,
+            };
+            invoices.set(row.confirmation_number, invoice);
+        }
+        invoice.total += Number(row.price ?? 0) + Number(row.price_bed ?? 0);
+    }
+
+    return matched
+        .map(number => invoices.get(number))
+        .filter(Boolean)
+        .sort((a, b) => a.confirmationNumber.localeCompare(b.confirmationNumber));
+};
+
+export default listInvoices;

--- a/server/routes/facturas.js
+++ b/server/routes/facturas.js
@@ -1,9 +1,14 @@
 import express from 'express';
-import { authGuard } from '../middleware/auth.js';
+import fs from 'fs';
+import { authGuard, adminGuard } from '../middleware/auth.js';
 import { generarFactura, previewFactura } from '../pdf/createPDF.js';
 import sendMail from '../mail/sendMail.js';
+import listInvoices from '../invoices/listInvoices.js';
+import executeQuery from '../sql/sqlUtils.js';
 
 const router = express.Router();
+
+const CONFIRMATION_NUMBER_RE = /^\d{11}$/;
 
 function parseBillBody(body) {
     const checkInDate = new Date(body.fechaCheckIn).toLocaleDateString('es-ES');
@@ -63,6 +68,60 @@ router.post('/factura', async function (req, res) {
     await generarFactura(reserva, cliente);
     sendMail(reserva.numeroFactura, cliente.nombre, cliente.apellidos, cliente.email, req.body.enviarACliente === true);
     res.send('Datos recibidos correctamente.');
+});
+
+router.get('/factura/list', async function (req, res) {
+    if (!adminGuard(req, res)) return;
+
+    try {
+        const { year, quarter } = req.query;
+        const invoices = await listInvoices(year, quarter);
+        res.json(invoices);
+    } catch (err) {
+        console.error('Error listando facturas:', err);
+        res.sendStatus(500);
+    }
+});
+
+router.get('/factura/:confirmationNumber/pdf', function (req, res) {
+    if (!adminGuard(req, res)) return;
+
+    const { confirmationNumber } = req.params;
+    if (!CONFIRMATION_NUMBER_RE.test(confirmationNumber)) return res.sendStatus(400);
+
+    try {
+        const buffer = fs.readFileSync('./facturas-cliente/' + confirmationNumber + '.pdf');
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader('Content-Disposition', `inline; filename="${confirmationNumber}.pdf"`);
+        res.send(buffer);
+    } catch (err) {
+        res.sendStatus(404);
+    }
+});
+
+router.post('/factura/:confirmationNumber/resend', async function (req, res) {
+    if (!adminGuard(req, res)) return;
+
+    const { confirmationNumber } = req.params;
+    if (!CONFIRMATION_NUMBER_RE.test(confirmationNumber)) return res.sendStatus(400);
+
+    try {
+        const rows = await executeQuery(
+            `SELECT c.name, c.surname, c.email FROM casademiranda.bookings b
+             INNER JOIN casademiranda.booking_customer bc ON b.booking_id = bc.booking_id
+             INNER JOIN casademiranda.customers c ON bc.customer_id = c.customer_id AND c.made_booking = 1
+             WHERE b.confirmation_number = ?`,
+            [confirmationNumber]
+        );
+        if (!rows || rows.length === 0) return res.sendStatus(404);
+
+        const { name, surname, email } = rows[0];
+        sendMail(confirmationNumber, name, surname, email);
+        res.sendStatus(200);
+    } catch (err) {
+        console.error('Error reenviando factura:', err);
+        res.sendStatus(500);
+    }
 });
 
 export default router;


### PR DESCRIPTION
## Resumen
- La pestaña "Facturas emitidas" de `/contabilidad` (implementada en GH-118, PR #134) se perdió silenciosamente al mergear GH-120 (PR de facturas de proveedores), cuya rama partía de antes del merge de GH-118 y sobrescribió `contabilidad/index.tsx` volviendo la pestaña a "Próximamente".
- Se restauran los ficheros originales de GH-118 (componente, interfaz, servicio, listado backend) y se reintegran las rutas `/factura/list`, `/factura/:confirmationNumber/pdf` y `/factura/:confirmationNumber/resend` en `server/routes/facturas.js`, conservando el cambio posterior de GH-157 (`enviarACliente`).

## Test plan
- [x] `npx tsc --noEmit` en frontend sin errores
- [x] `node --check` sobre los ficheros backend modificados
- [x] Probado en navegador (rebuild de docker) por el usuario: pestaña "Facturas emitidas" carga correctamente y "Facturas proveedores" sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)