### PR TITLE
[GH-176][GH-177]: plantillas de extracción de facturas de proveedor y desglose multi-IVA

### DIFF
--- a/front/admin-casademiranda/components/contabilidad/facturas-proveedores.tsx
+++ b/front/admin-casademiranda/components/contabilidad/facturas-proveedores.tsx
@@ -7,8 +7,9 @@ import {
     getPendingSupplierEmails,
     viewSupplierInvoiceFile,
     viewPendingEmailAttachment,
+    extractPendingEmailInvoiceData,
 } from '@/services/supplierInvoices';
-import type { SupplierInvoice, PendingSupplierEmail } from '@/interfaces/supplierInvoice';
+import type { SupplierInvoice, PendingSupplierEmail, VatLine } from '@/interfaces/supplierInvoice';
 import ProveedoresModal from '@/components/contabilidad/proveedores-modal';
 
 const inputClass = "mt-1 w-full border border-gray-light rounded-lg px-3 py-2 text-gray-dark text-sm focus:outline-none focus:border-gray";
@@ -22,14 +23,18 @@ function currentQuarter() {
     return Math.ceil((new Date().getMonth() + 1) / 3);
 }
 
+interface VatLineForm {
+    baseAmount: string;
+    vatPercent: string;
+}
+
 interface FormState {
     id: number | null;
     invoiceNumber: string;
     nif: string;
     date: string;
     supplierName: string;
-    baseAmount: string;
-    vatPercent: string;
+    vatLines: VatLineForm[];
     totalAmount: string;
     reference: string;
     notes: string;
@@ -41,9 +46,19 @@ interface FormState {
 
 const emptyForm: FormState = {
     id: null, invoiceNumber: '', nif: '', date: '', supplierName: '',
-    baseAmount: '', vatPercent: '21', totalAmount: '', reference: '', notes: '', emailUid: null,
+    vatLines: [], totalAmount: '', reference: '', notes: '', emailUid: null,
     file: null, hasExistingFile: false, fromEmailAttachment: false,
 };
+
+function computeTotalFromLines(vatLines: VatLineForm[]): string {
+    const sum = vatLines.reduce((acc, l) => {
+        const base = parseFloat(l.baseAmount);
+        const vat = parseFloat(l.vatPercent);
+        if (isNaN(base) || isNaN(vat)) return acc;
+        return acc + base + (base * vat / 100);
+    }, 0);
+    return sum > 0 ? sum.toFixed(2) : '';
+}
 
 export default function FacturasProveedores() {
     const [year, setYear] = useState(currentYear);
@@ -59,6 +74,7 @@ export default function FacturasProveedores() {
     const [checkingMail, setCheckingMail] = useState(false);
     const [pendingEmails, setPendingEmails] = useState<PendingSupplierEmail[] | null>(null);
     const [showSuppliers, setShowSuppliers] = useState(false);
+    const [extractingData, setExtractingData] = useState(false);
 
     useEffect(() => { load(); }, [year, quarter]);
 
@@ -87,8 +103,7 @@ export default function FacturasProveedores() {
             nif: inv.nif ?? '',
             date: inv.date.slice(0, 10),
             supplierName: inv.supplierName,
-            baseAmount: inv.baseAmount != null ? String(inv.baseAmount) : '',
-            vatPercent: inv.vatRate != null ? String(inv.vatRate * 100) : '',
+            vatLines: inv.vatLines.map(l => ({ baseAmount: String(l.baseAmount), vatPercent: String(l.vatRate * 100) })),
             totalAmount: String(inv.totalAmount),
             reference: inv.reference ?? '',
             notes: inv.notes ?? '',
@@ -99,7 +114,7 @@ export default function FacturasProveedores() {
         });
     }
 
-    function handleSelectEmail(email: PendingSupplierEmail) {
+    async function handleSelectEmail(email: PendingSupplierEmail) {
         setPendingEmails(null);
         setFormError('');
         setForm({
@@ -110,20 +125,50 @@ export default function FacturasProveedores() {
             emailUid: email.uid,
             fromEmailAttachment: email.hasAttachment,
         });
+
+        if (!email.hasAttachment) return;
+        setExtractingData(true);
+        try {
+            const extracted = await extractPendingEmailInvoiceData(email.uid, email.supplierId);
+            setForm(prev => {
+                if (!prev) return prev;
+                const next = { ...prev };
+                if (extracted.invoiceNumber) next.invoiceNumber = extracted.invoiceNumber;
+                if (extracted.nif) next.nif = extracted.nif;
+                if (extracted.baseAmount != null && extracted.vatRatePercent != null) {
+                    next.vatLines = [{ baseAmount: String(extracted.baseAmount), vatPercent: String(extracted.vatRatePercent) }];
+                }
+                if (extracted.totalAmount != null) next.totalAmount = String(extracted.totalAmount);
+                return next;
+            });
+        } catch (e: any) {
+            console.error('Error extrayendo datos de factura de proveedor:', e.message);
+        } finally {
+            setExtractingData(false);
+        }
     }
 
     function updateForm<K extends keyof FormState>(key: K, value: FormState[K]) {
+        setForm(prev => prev ? { ...prev, [key]: value } : prev);
+    }
+
+    function addVatLine() {
+        setForm(prev => prev ? { ...prev, vatLines: [...prev.vatLines, { baseAmount: '', vatPercent: '21' }] } : prev);
+    }
+
+    function removeVatLine(index: number) {
         setForm(prev => {
             if (!prev) return prev;
-            const next = { ...prev, [key]: value };
-            if (key === 'baseAmount' || key === 'vatPercent') {
-                const base = parseFloat(next.baseAmount);
-                const vat = parseFloat(next.vatPercent);
-                if (!isNaN(base) && !isNaN(vat)) {
-                    next.totalAmount = (base + base * vat / 100).toFixed(2);
-                }
-            }
-            return next;
+            const vatLines = prev.vatLines.filter((_, i) => i !== index);
+            return { ...prev, vatLines, totalAmount: computeTotalFromLines(vatLines) };
+        });
+    }
+
+    function updateVatLine(index: number, key: keyof VatLineForm, value: string) {
+        setForm(prev => {
+            if (!prev) return prev;
+            const vatLines = prev.vatLines.map((l, i) => i === index ? { ...l, [key]: value } : l);
+            return { ...prev, vatLines, totalAmount: computeTotalFromLines(vatLines) };
         });
     }
 
@@ -137,16 +182,15 @@ export default function FacturasProveedores() {
         setSaving(true);
         setFormError('');
         try {
-            const base = parseFloat(form.baseAmount);
-            const vat = parseFloat(form.vatPercent);
+            const vatLines = form.vatLines
+                .map(l => ({ baseAmount: parseFloat(l.baseAmount), vatRate: parseFloat(l.vatPercent) / 100 }))
+                .filter(l => !isNaN(l.baseAmount) && !isNaN(l.vatRate));
             const payload = {
                 invoiceNumber: form.invoiceNumber || null,
                 nif: form.nif || null,
                 date: form.date,
                 supplierName: form.supplierName.trim(),
-                baseAmount: isNaN(base) ? null : base,
-                vatRate: isNaN(vat) ? null : vat / 100,
-                vatAmount: (!isNaN(base) && !isNaN(vat)) ? Number((base * vat / 100).toFixed(2)) : null,
+                vatLines,
                 totalAmount: parseFloat(form.totalAmount),
                 reference: form.reference || null,
                 notes: form.notes || null,
@@ -212,10 +256,16 @@ export default function FacturasProveedores() {
     }
 
     const totals = invoices.reduce((acc, i) => ({
-        base: acc.base + (i.baseAmount ?? 0),
-        vat: acc.vat + (i.vatAmount ?? 0),
+        base: acc.base + i.vatLines.reduce((s, l) => s + l.baseAmount, 0),
+        vat: acc.vat + i.vatLines.reduce((s, l) => s + l.vatAmount, 0),
         total: acc.total + i.totalAmount,
     }), { base: 0, vat: 0, total: 0 });
+
+    function formatVatRateColumn(vatLines: VatLine[]): string {
+        if (vatLines.length === 0) return '—';
+        if (vatLines.length === 1) return (vatLines[0].vatRate * 100).toFixed(0) + '%';
+        return 'varios';
+    }
 
     return (
         <div>
@@ -274,8 +324,12 @@ export default function FacturasProveedores() {
                                     <td className="py-2 px-3 text-gray-dark font-medium">{inv.invoiceNumber ?? '—'}</td>
                                     <td className="py-2 px-3">{inv.supplierName}</td>
                                     <td className="py-2 px-3">{new Date(inv.date).toLocaleDateString('es-ES')}</td>
-                                    <td className="py-2 px-3 text-right">{inv.baseAmount != null ? inv.baseAmount.toFixed(2) + ' €' : '—'}</td>
-                                    <td className="py-2 px-3 text-right">{inv.vatRate != null ? (inv.vatRate * 100).toFixed(0) + '%' : '—'}</td>
+                                    <td className="py-2 px-3 text-right">
+                                        {inv.vatLines.length > 0 ? inv.vatLines.reduce((s, l) => s + l.baseAmount, 0).toFixed(2) + ' €' : '—'}
+                                    </td>
+                                    <td className="py-2 px-3 text-right" title={inv.vatLines.map(l => (l.vatRate * 100).toFixed(0) + '%').join(', ')}>
+                                        {formatVatRateColumn(inv.vatLines)}
+                                    </td>
                                     <td className="py-2 px-3 text-right">{inv.totalAmount.toFixed(2)} €</td>
                                     <td className="py-2 px-3 text-right whitespace-nowrap">
                                         {inv.filePath && (
@@ -319,6 +373,7 @@ export default function FacturasProveedores() {
                     <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-lg mx-4">
                         <h3 className="text-sm font-semibold text-gray-dark mb-4">
                             {form.id ? 'Editar factura de proveedor' : 'Nueva factura de proveedor'}
+                            {extractingData && <span className="text-xs text-gray font-normal ml-2">extrayendo datos del adjunto...</span>}
                         </h3>
                         <form onSubmit={handleSave} noValidate>
                             <div className="grid grid-cols-2 gap-4 mb-4">
@@ -342,15 +397,30 @@ export default function FacturasProveedores() {
                                     <input className={inputClass} type="date" value={form.date}
                                         onChange={e => updateForm('date', e.target.value)} />
                                 </div>
-                                <div>
-                                    <label className={labelClass}>Base</label>
-                                    <input className={inputClass} type="number" step="0.01" value={form.baseAmount}
-                                        onChange={e => updateForm('baseAmount', e.target.value)} />
-                                </div>
-                                <div>
-                                    <label className={labelClass}>IVA %</label>
-                                    <input className={inputClass} type="number" step="0.01" value={form.vatPercent}
-                                        onChange={e => updateForm('vatPercent', e.target.value)} />
+                                <div className="col-span-2">
+                                    <label className={labelClass}>Líneas de IVA</label>
+                                    {form.vatLines.map((line, i) => {
+                                        const base = parseFloat(line.baseAmount);
+                                        const vat = parseFloat(line.vatPercent);
+                                        const cuota = (!isNaN(base) && !isNaN(vat)) ? (base * vat / 100).toFixed(2) + ' €' : '—';
+                                        return (
+                                            <div key={i} className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2 items-center mt-1">
+                                                <input className={inputClass} type="number" step="0.01" placeholder="Base"
+                                                    value={line.baseAmount} onChange={e => updateVatLine(i, 'baseAmount', e.target.value)} />
+                                                <input className={inputClass} type="number" step="0.01" placeholder="IVA %"
+                                                    value={line.vatPercent} onChange={e => updateVatLine(i, 'vatPercent', e.target.value)} />
+                                                <span className="text-sm text-gray-dark">{cuota}</span>
+                                                <button type="button" onClick={() => removeVatLine(i)}
+                                                    className="text-gray hover:text-orange transition-colors text-xs font-semibold">
+                                                    Quitar
+                                                </button>
+                                            </div>
+                                        );
+                                    })}
+                                    <button type="button" onClick={addVatLine}
+                                        className="text-xs text-gray hover:text-gray-dark transition-colors mt-2 underline">
+                                        + Añadir línea de IVA
+                                    </button>
                                 </div>
                                 <div>
                                     <label className={labelClass}>Total *</label>

--- a/front/admin-casademiranda/components/contabilidad/proveedores-modal.tsx
+++ b/front/admin-casademiranda/components/contabilidad/proveedores-modal.tsx
@@ -1,9 +1,41 @@
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { listSuppliers, createSupplier, updateSupplier, deleteSupplier } from '@/services/suppliers';
-import type { Supplier } from '@/interfaces/supplier';
+import type { Supplier, SupplierTemplate } from '@/interfaces/supplier';
 
 const inputClass = "mt-1 w-full border border-gray-light rounded-lg px-3 py-2 text-gray-dark text-sm focus:outline-none focus:border-gray";
+const monoInputClass = inputClass + " font-mono text-xs";
 const labelClass = "text-xs text-gray uppercase tracking-wide block";
+
+const emptyTemplate: SupplierTemplate = {
+    invoiceNumberPattern: null,
+    nifPattern: null,
+    baseAmountPattern: null,
+    vatRatePattern: null,
+    totalAmountPattern: null,
+};
+
+const TEMPLATE_FIELDS: { key: keyof SupplierTemplate; label: string; placeholder: string }[] = [
+    { key: 'invoiceNumberPattern', label: 'Nº Factura', placeholder: String.raw`Factura n[ºo]\.?\s*([\w-]+)` },
+    { key: 'nifPattern', label: 'NIF', placeholder: String.raw`NIF:?\s*([A-Z0-9]+)` },
+    { key: 'baseAmountPattern', label: 'Base imponible', placeholder: String.raw`Base imponible\s*([\d.,]+)` },
+    { key: 'vatRatePattern', label: 'IVA %', placeholder: String.raw`IVA\s*\((\d+)%\)` },
+    { key: 'totalAmountPattern', label: 'Total', placeholder: String.raw`Total factura\s*([\d.,]+)\s*€` },
+];
+
+function TemplateFields({ value, onChange }: { value: SupplierTemplate; onChange: (t: SupplierTemplate) => void }) {
+    return (
+        <div className="grid grid-cols-1 gap-2 mt-2">
+            {TEMPLATE_FIELDS.map(f => (
+                <div key={f.key}>
+                    <label className={labelClass}>{f.label}</label>
+                    <input className={monoInputClass} placeholder={f.placeholder}
+                        value={value[f.key] ?? ''}
+                        onChange={e => onChange({ ...value, [f.key]: e.target.value })} />
+                </div>
+            ))}
+        </div>
+    );
+}
 
 interface Props {
     onClose: () => void;
@@ -17,6 +49,8 @@ export default function ProveedoresModal({ onClose }: Props) {
     const [name, setName] = useState('');
     const [domain, setDomain] = useState('');
     const [subjectKeyword, setSubjectKeyword] = useState('');
+    const [template, setTemplate] = useState<SupplierTemplate>(emptyTemplate);
+    const [showTemplate, setShowTemplate] = useState(false);
     const [creating, setCreating] = useState(false);
     const [createError, setCreateError] = useState('');
 
@@ -24,6 +58,8 @@ export default function ProveedoresModal({ onClose }: Props) {
     const [editName, setEditName] = useState('');
     const [editDomain, setEditDomain] = useState('');
     const [editSubjectKeyword, setEditSubjectKeyword] = useState('');
+    const [editTemplate, setEditTemplate] = useState<SupplierTemplate>(emptyTemplate);
+    const [showEditTemplate, setShowEditTemplate] = useState(false);
     const [savingEdit, setSavingEdit] = useState(false);
     const [editError, setEditError] = useState('');
 
@@ -50,10 +86,12 @@ export default function ProveedoresModal({ onClose }: Props) {
         setCreating(true);
         setCreateError('');
         try {
-            await createSupplier(name.trim(), domain.trim(), subjectKeyword.trim() || null);
+            await createSupplier(name.trim(), domain.trim(), subjectKeyword.trim() || null, template);
             setName('');
             setDomain('');
             setSubjectKeyword('');
+            setTemplate(emptyTemplate);
+            setShowTemplate(false);
             await load();
         } catch (e: any) {
             setCreateError(e.message);
@@ -65,6 +103,14 @@ export default function ProveedoresModal({ onClose }: Props) {
     function startEdit(s: Supplier) {
         setEditingId(s.id);
         setEditName(s.name);
+        setEditTemplate({
+            invoiceNumberPattern: s.invoiceNumberPattern,
+            nifPattern: s.nifPattern,
+            baseAmountPattern: s.baseAmountPattern,
+            vatRatePattern: s.vatRatePattern,
+            totalAmountPattern: s.totalAmountPattern,
+        });
+        setShowEditTemplate(false);
         setEditDomain(s.domain);
         setEditSubjectKeyword(s.subjectKeyword ?? '');
         setEditError('');
@@ -78,7 +124,7 @@ export default function ProveedoresModal({ onClose }: Props) {
         setSavingEdit(true);
         setEditError('');
         try {
-            await updateSupplier(id, editName.trim(), editDomain.trim(), editSubjectKeyword.trim() || null);
+            await updateSupplier(id, editName.trim(), editDomain.trim(), editSubjectKeyword.trim() || null, editTemplate);
             setEditingId(null);
             await load();
         } catch (e: any) {
@@ -127,6 +173,11 @@ export default function ProveedoresModal({ onClose }: Props) {
                             </button>
                         </div>
                     </div>
+                    <button type="button" onClick={() => setShowTemplate(v => !v)}
+                        className="text-xs text-gray hover:text-gray-dark transition-colors mt-2 underline">
+                        {showTemplate ? 'Ocultar plantilla de extracción' : 'Plantilla de extracción (opcional)'}
+                    </button>
+                    {showTemplate && <TemplateFields value={template} onChange={setTemplate} />}
                     {createError && <p className="text-xs text-orange mt-2">{createError}</p>}
                 </form>
 
@@ -147,7 +198,8 @@ export default function ProveedoresModal({ onClose }: Props) {
                             </thead>
                             <tbody>
                                 {suppliers.map(s => (
-                                    <tr key={s.id} className="border-b border-gray-light last:border-0">
+                                    <Fragment key={s.id}>
+                                    <tr className="border-b border-gray-light last:border-0">
                                         {editingId === s.id ? (
                                             <>
                                                 <td className="py-2 px-3">
@@ -163,6 +215,10 @@ export default function ProveedoresModal({ onClose }: Props) {
                                                         onChange={e => setEditSubjectKeyword(e.target.value)} />
                                                 </td>
                                                 <td className="py-2 px-3 text-right whitespace-nowrap">
+                                                    <button onClick={() => setShowEditTemplate(v => !v)}
+                                                        className="text-gray hover:text-gray-dark transition-colors text-xs font-semibold mr-3">
+                                                        Plantilla
+                                                    </button>
                                                     <button onClick={() => handleSaveEdit(s.id)} disabled={savingEdit}
                                                         className="text-gray hover:text-green transition-colors text-xs font-semibold mr-3 disabled:opacity-40">
                                                         Guardar
@@ -191,6 +247,14 @@ export default function ProveedoresModal({ onClose }: Props) {
                                             </>
                                         )}
                                     </tr>
+                                    {editingId === s.id && showEditTemplate && (
+                                        <tr className="border-b border-gray-light last:border-0">
+                                            <td colSpan={4} className="py-2 px-3 bg-gray-light bg-opacity-20">
+                                                <TemplateFields value={editTemplate} onChange={setEditTemplate} />
+                                            </td>
+                                        </tr>
+                                    )}
+                                    </Fragment>
                                 ))}
                                 {suppliers.length === 0 && (
                                     <tr><td colSpan={4} className="py-4 px-3 text-center text-gray text-sm">Sin proveedores registrados</td></tr>

--- a/front/admin-casademiranda/interfaces/supplier.ts
+++ b/front/admin-casademiranda/interfaces/supplier.ts
@@ -3,4 +3,17 @@ export interface Supplier {
     name: string;
     domain: string;
     subjectKeyword: string | null;
+    invoiceNumberPattern: string | null;
+    nifPattern: string | null;
+    baseAmountPattern: string | null;
+    vatRatePattern: string | null;
+    totalAmountPattern: string | null;
+}
+
+export interface SupplierTemplate {
+    invoiceNumberPattern: string | null;
+    nifPattern: string | null;
+    baseAmountPattern: string | null;
+    vatRatePattern: string | null;
+    totalAmountPattern: string | null;
 }

--- a/front/admin-casademiranda/interfaces/supplierInvoice.ts
+++ b/front/admin-casademiranda/interfaces/supplierInvoice.ts
@@ -1,16 +1,25 @@
+export interface VatLine {
+    baseAmount: number;
+    vatRate: number;
+    vatAmount: number;
+}
+
 export interface SupplierInvoice {
     id: number;
     invoiceNumber: string | null;
     nif: string | null;
     date: string;
     supplierName: string;
-    baseAmount: number | null;
-    vatRate: number | null;
-    vatAmount: number | null;
+    vatLines: VatLine[];
     totalAmount: number;
     reference: string | null;
     notes: string | null;
     filePath: string | null;
+}
+
+export interface SupplierInvoiceVatLineInput {
+    baseAmount: number;
+    vatRate: number;
 }
 
 export interface SupplierInvoiceInput {
@@ -18,9 +27,7 @@ export interface SupplierInvoiceInput {
     nif?: string | null;
     date: string;
     supplierName: string;
-    baseAmount?: number | null;
-    vatRate?: number | null;
-    vatAmount?: number | null;
+    vatLines: SupplierInvoiceVatLineInput[];
     totalAmount: number;
     reference?: string | null;
     notes?: string | null;
@@ -33,6 +40,15 @@ export interface PendingSupplierEmail {
     subject: string;
     from: string;
     date: string;
+    supplierId: number;
     supplierName: string;
     hasAttachment: boolean;
+}
+
+export interface ExtractedInvoiceData {
+    invoiceNumber: string | null;
+    nif: string | null;
+    baseAmount: number | null;
+    vatRatePercent: number | null;
+    totalAmount: number | null;
 }

--- a/front/admin-casademiranda/services/supplierInvoices.ts
+++ b/front/admin-casademiranda/services/supplierInvoices.ts
@@ -1,4 +1,4 @@
-import type { SupplierInvoice, SupplierInvoiceInput, PendingSupplierEmail } from '../interfaces/supplierInvoice';
+import type { SupplierInvoice, SupplierInvoiceInput, PendingSupplierEmail, ExtractedInvoiceData } from '../interfaces/supplierInvoice';
 import { getToken } from '../auth/auth';
 import { API_HOST } from './config';
 
@@ -18,6 +18,8 @@ function toFormData(data: SupplierInvoiceInput): FormData {
     Object.entries(data).forEach(([key, value]) => {
         if (key === 'file') {
             if (value) formData.append('file', value as File);
+        } else if (key === 'vatLines') {
+            formData.append('vatLines', JSON.stringify(value ?? []));
         } else if (value !== null && value !== undefined) {
             formData.append(key, String(value));
         }
@@ -76,6 +78,18 @@ export async function viewPendingEmailAttachment(uid: number): Promise<Blob> {
     });
     if (!res.ok) throw new Error(`Error HTTP ${res.status}`);
     return res.blob();
+}
+
+export async function extractPendingEmailInvoiceData(uid: number, supplierId: number): Promise<ExtractedInvoiceData> {
+    const token = getToken();
+    const res = await fetch(`${API_URL}/email-pending/${uid}/extract?supplierId=${supplierId}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Error HTTP ${res.status}`);
+    }
+    return res.json();
 }
 
 export async function getPendingSupplierEmails(): Promise<PendingSupplierEmail[]> {

--- a/front/admin-casademiranda/services/suppliers.ts
+++ b/front/admin-casademiranda/services/suppliers.ts
@@ -1,4 +1,4 @@
-import type { Supplier } from '../interfaces/supplier';
+import type { Supplier, SupplierTemplate } from '../interfaces/supplier';
 import { getToken } from '../auth/auth';
 import { API_HOST } from './config';
 
@@ -13,12 +13,12 @@ export async function listSuppliers(): Promise<Supplier[]> {
     return res.json();
 }
 
-export async function createSupplier(name: string, domain: string, subjectKeyword: string | null): Promise<void> {
+export async function createSupplier(name: string, domain: string, subjectKeyword: string | null, template: SupplierTemplate): Promise<void> {
     const token = getToken();
     const res = await fetch(API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({ name, domain, subjectKeyword })
+        body: JSON.stringify({ name, domain, subjectKeyword, ...template })
     });
     if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -26,12 +26,12 @@ export async function createSupplier(name: string, domain: string, subjectKeywor
     }
 }
 
-export async function updateSupplier(id: number, name: string, domain: string, subjectKeyword: string | null): Promise<void> {
+export async function updateSupplier(id: number, name: string, domain: string, subjectKeyword: string | null, template: SupplierTemplate): Promise<void> {
     const token = getToken();
     const res = await fetch(`${API_URL}/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({ name, domain, subjectKeyword })
+        body: JSON.stringify({ name, domain, subjectKeyword, ...template })
     });
     if (!res.ok) {
         const body = await res.json().catch(() => ({}));

--- a/infrastructure/bbdd/migrations/GH-176-supplier-invoice-templates.sql
+++ b/infrastructure/bbdd/migrations/GH-176-supplier-invoice-templates.sql
@@ -1,0 +1,6 @@
+ALTER TABLE casademiranda.suppliers
+  ADD COLUMN invoice_number_pattern VARCHAR(255) NULL,
+  ADD COLUMN nif_pattern            VARCHAR(255) NULL,
+  ADD COLUMN base_amount_pattern    VARCHAR(255) NULL,
+  ADD COLUMN vat_rate_pattern       VARCHAR(255) NULL,
+  ADD COLUMN total_amount_pattern   VARCHAR(255) NULL;

--- a/infrastructure/bbdd/migrations/GH-177-supplier-invoice-vat-lines.sql
+++ b/infrastructure/bbdd/migrations/GH-177-supplier-invoice-vat-lines.sql
@@ -1,0 +1,17 @@
+CREATE TABLE casademiranda.supplier_invoice_vat_lines (
+  id                  INT AUTO_INCREMENT PRIMARY KEY,
+  supplier_invoice_id INT NOT NULL,
+  base_amount         DECIMAL(10,2) NOT NULL,
+  vat_rate            DECIMAL(5,4) NOT NULL,
+  vat_amount          DECIMAL(10,2) NOT NULL,
+  FOREIGN KEY (supplier_invoice_id) REFERENCES casademiranda.supplier_invoices(id) ON DELETE CASCADE
+);
+
+INSERT INTO casademiranda.supplier_invoice_vat_lines (supplier_invoice_id, base_amount, vat_rate, vat_amount)
+SELECT id, base_amount, vat_rate, vat_amount FROM casademiranda.supplier_invoices
+WHERE base_amount IS NOT NULL AND vat_rate IS NOT NULL AND vat_amount IS NOT NULL;
+
+ALTER TABLE casademiranda.supplier_invoices
+  DROP COLUMN base_amount,
+  DROP COLUMN vat_rate,
+  DROP COLUMN vat_amount;

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:current-alpine3.20
 
-RUN apk add --no-cache tesseract-ocr tesseract-ocr-data-eng tesseract-ocr-data-spa
+RUN apk add --no-cache tesseract-ocr tesseract-ocr-data-eng tesseract-ocr-data-spa poppler-utils
 
 # Create app directory
 WORKDIR /server

--- a/server/invoices/extractSupplierInvoiceData.js
+++ b/server/invoices/extractSupplierInvoiceData.js
@@ -1,0 +1,131 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { PDFParse } from 'pdf-parse';
+
+const execFileAsync = promisify(execFile);
+
+const MIN_NATIVE_TEXT_LENGTH = 30;
+
+function tmpName(prefix, extension) {
+    return path.join(os.tmpdir(), `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2)}${extension}`);
+}
+
+async function extractNativePdfText(buffer) {
+    const parser = new PDFParse({ data: buffer });
+    try {
+        const result = await parser.getText();
+        return (result.text ?? '').trim();
+    } finally {
+        await parser.destroy();
+    }
+}
+
+async function ocrImageFile(imagePath) {
+    const { stdout } = await execFileAsync('tesseract', [imagePath, 'stdout', '-l', 'spa', '--oem', '1', '--psm', '6']);
+    return stdout;
+}
+
+async function ocrScannedPdf(buffer) {
+    const tmpPdf = tmpName('invoice', '.pdf');
+    const pagePrefix = tmpName('invoice_page', '');
+    const tmpFiles = [tmpPdf];
+    try {
+        fs.writeFileSync(tmpPdf, buffer);
+        await execFileAsync('pdftoppm', ['-png', '-r', '200', tmpPdf, pagePrefix]);
+
+        const dir = path.dirname(pagePrefix);
+        const prefixName = path.basename(pagePrefix);
+        const pages = fs.readdirSync(dir)
+            .filter(f => f.startsWith(prefixName))
+            .sort()
+            .map(f => path.join(dir, f));
+        tmpFiles.push(...pages);
+
+        let text = '';
+        for (const page of pages) {
+            text += (await ocrImageFile(page)) + '\n';
+        }
+        return text.trim();
+    } finally {
+        tmpFiles.forEach(f => { try { fs.unlinkSync(f); } catch { /* ya no existe */ } });
+    }
+}
+
+async function ocrImageAttachment(buffer, extension) {
+    const tmpImage = tmpName('invoice', `.${extension || 'png'}`);
+    try {
+        fs.writeFileSync(tmpImage, buffer);
+        return (await ocrImageFile(tmpImage)).trim();
+    } finally {
+        try { fs.unlinkSync(tmpImage); } catch { /* ya no existe */ }
+    }
+}
+
+async function getAttachmentText(buffer, contentType, filename) {
+    const isPdf = (contentType ?? '').toLowerCase() === 'application/pdf' || (filename ?? '').toLowerCase().endsWith('.pdf');
+    if (isPdf) {
+        try {
+            const text = await extractNativePdfText(buffer);
+            if (text.length >= MIN_NATIVE_TEXT_LENGTH) return text;
+        } catch (err) {
+            console.error('Error extrayendo texto nativo del PDF:', err);
+        }
+        // PDF sin texto embebido (escaneado): OCR pagina a pagina.
+        return ocrScannedPdf(buffer);
+    }
+    const extension = filename?.split('.').pop()?.toLowerCase();
+    return ocrImageAttachment(buffer, extension);
+}
+
+function parseSpanishNumber(str) {
+    if (!str) return null;
+    const cleaned = str.replace(/[^\d.,-]/g, '');
+    if (!cleaned) return null;
+    // Formato español: punto de miles, coma decimal (p.ej. "1.234,56").
+    const normalized = cleaned.includes(',') ? cleaned.replace(/\./g, '').replace(',', '.') : cleaned;
+    const num = Number(normalized);
+    return Number.isFinite(num) ? num : null;
+}
+
+function extractField(text, pattern) {
+    if (!pattern) return null;
+    try {
+        const match = new RegExp(pattern, 'i').exec(text);
+        if (!match) return null;
+        return (match[1] ?? match[0]).trim();
+    } catch (err) {
+        console.error(`Patrón de extracción de factura inválido "${pattern}":`, err.message);
+        return null;
+    }
+}
+
+function cleanNif(str) {
+    if (!str) return null;
+    const cleaned = str.replace(/[^A-Z0-9]/gi, '').toUpperCase();
+    return cleaned || null;
+}
+
+function applyInvoiceTemplate(text, template) {
+    return {
+        invoiceNumber: extractField(text, template.invoiceNumberPattern),
+        nif: cleanNif(extractField(text, template.nifPattern)),
+        baseAmount: parseSpanishNumber(extractField(text, template.baseAmountPattern)),
+        vatRatePercent: parseSpanishNumber(extractField(text, template.vatRatePattern)),
+        totalAmount: parseSpanishNumber(extractField(text, template.totalAmountPattern)),
+    };
+}
+
+const EMPTY_RESULT = { invoiceNumber: null, nif: null, baseAmount: null, vatRatePercent: null, totalAmount: null };
+
+export async function extractSupplierInvoiceFields(buffer, contentType, filename, template) {
+    try {
+        const text = await getAttachmentText(buffer, contentType, filename);
+        return applyInvoiceTemplate(text, template ?? {});
+    } catch (err) {
+        console.error('Error extrayendo datos de factura de proveedor:', err);
+        return EMPTY_RESULT;
+    }
+}

--- a/server/invoices/supplierInvoices.js
+++ b/server/invoices/supplierInvoices.js
@@ -9,24 +9,51 @@ function quarterRange(year, quarter) {
     return { startDate, endDate };
 }
 
+async function insertVatLines(invoiceId, vatLines) {
+    if (!vatLines || vatLines.length === 0) return;
+    const values = vatLines.map(l => [invoiceId, l.baseAmount, l.vatRate, Number((l.baseAmount * l.vatRate).toFixed(2))]);
+    await executeQuery(
+        `INSERT INTO casademiranda.supplier_invoice_vat_lines (supplier_invoice_id, base_amount, vat_rate, vat_amount) VALUES ?`,
+        [values]
+    );
+}
+
+async function getVatLinesByInvoiceIds(ids) {
+    if (!ids || ids.length === 0) return new Map();
+    const rows = await executeQuery(
+        `SELECT supplier_invoice_id AS supplierInvoiceId, base_amount AS baseAmount, vat_rate AS vatRate, vat_amount AS vatAmount
+         FROM casademiranda.supplier_invoice_vat_lines
+         WHERE supplier_invoice_id IN (?)`,
+        [ids]
+    );
+    const byInvoice = new Map();
+    for (const row of rows ?? []) {
+        const list = byInvoice.get(row.supplierInvoiceId) ?? [];
+        list.push({
+            baseAmount: Number(row.baseAmount),
+            vatRate: Number(row.vatRate),
+            vatAmount: Number(row.vatAmount),
+        });
+        byInvoice.set(row.supplierInvoiceId, list);
+    }
+    return byInvoice;
+}
+
 export async function listSupplierInvoices(year, quarter) {
     const { startDate, endDate } = quarterRange(year, quarter);
-    const rows = await executeQuery(
+    const invoices = await executeQuery(
         `SELECT id, invoice_number AS invoiceNumber, nif, date, supplier_name AS supplierName,
-                base_amount AS baseAmount, vat_rate AS vatRate, vat_amount AS vatAmount,
                 total_amount AS totalAmount, reference, notes, file_path AS filePath
          FROM casademiranda.supplier_invoices
          WHERE date BETWEEN ? AND ?
          ORDER BY date, id`,
         [startDate, endDate]
     );
-    // mysql2 devuelve las columnas DECIMAL como string; el frontend necesita numeros (toFixed, sumas).
-    return (rows ?? []).map(row => ({
+    const linesByInvoice = await getVatLinesByInvoiceIds((invoices ?? []).map(i => i.id));
+    return (invoices ?? []).map(row => ({
         ...row,
-        baseAmount: row.baseAmount != null ? Number(row.baseAmount) : null,
-        vatRate: row.vatRate != null ? Number(row.vatRate) : null,
-        vatAmount: row.vatAmount != null ? Number(row.vatAmount) : null,
         totalAmount: Number(row.totalAmount),
+        vatLines: linesByInvoice.get(row.id) ?? [],
     }));
 }
 
@@ -53,29 +80,30 @@ export async function listRegisteredEmailUids() {
 }
 
 export async function createSupplierInvoice(data) {
-    const { invoiceNumber, nif, date, supplierName, baseAmount, vatRate, vatAmount, totalAmount, reference, notes, emailUid } = data;
+    const { invoiceNumber, nif, date, supplierName, totalAmount, reference, notes, emailUid, vatLines } = data;
     const result = await executeQuery(
         `INSERT INTO casademiranda.supplier_invoices
-            (invoice_number, nif, date, supplier_name, base_amount, vat_rate, vat_amount, total_amount, reference, notes, email_uid)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [invoiceNumber ?? null, nif ?? null, date, supplierName,
-         baseAmount ?? null, vatRate ?? null, vatAmount ?? null, totalAmount,
+            (invoice_number, nif, date, supplier_name, total_amount, reference, notes, email_uid)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [invoiceNumber ?? null, nif ?? null, date, supplierName, totalAmount,
          reference ?? null, notes ?? null, emailUid ?? null]
     );
-    return result.insertId;
+    const id = result.insertId;
+    await insertVatLines(id, vatLines);
+    return id;
 }
 
 export async function updateSupplierInvoice(id, data) {
-    const { invoiceNumber, nif, date, supplierName, baseAmount, vatRate, vatAmount, totalAmount, reference, notes } = data;
+    const { invoiceNumber, nif, date, supplierName, totalAmount, reference, notes, vatLines } = data;
     await executeQuery(
         `UPDATE casademiranda.supplier_invoices
-         SET invoice_number = ?, nif = ?, date = ?, supplier_name = ?, base_amount = ?,
-             vat_rate = ?, vat_amount = ?, total_amount = ?, reference = ?, notes = ?
+         SET invoice_number = ?, nif = ?, date = ?, supplier_name = ?, total_amount = ?, reference = ?, notes = ?
          WHERE id = ?`,
-        [invoiceNumber ?? null, nif ?? null, date, supplierName,
-         baseAmount ?? null, vatRate ?? null, vatAmount ?? null, totalAmount,
+        [invoiceNumber ?? null, nif ?? null, date, supplierName, totalAmount,
          reference ?? null, notes ?? null, id]
     );
+    await executeQuery('DELETE FROM casademiranda.supplier_invoice_vat_lines WHERE supplier_invoice_id = ?', [id]);
+    await insertVatLines(id, vatLines);
 }
 
 export async function deleteSupplierInvoice(id) {

--- a/server/mail/checkSupplierMails.js
+++ b/server/mail/checkSupplierMails.js
@@ -1,5 +1,12 @@
 import { ImapFlow } from 'imapflow';
 
+// Por debajo del timeout de nginx (60s) para que, si el correo va lento o no responde,
+// el backend falle rápido con un error claro en vez de dejar la petición colgada hasta
+// que nginx corte la conexión con un 504 -- que además no deshace lo que ya se haya
+// guardado en BD, pudiendo dar lugar a duplicados si el usuario reintenta.
+const IMAP_CONNECTION_TIMEOUT = 15000;
+const IMAP_SOCKET_TIMEOUT = 30000;
+
 async function getClient(user, password) {
     const client = new ImapFlow({
         host: 'imap.gmail.com',
@@ -7,9 +14,21 @@ async function getClient(user, password) {
         secure: true,
         auth: { user, pass: password },
         logger: false,
+        connectionTimeout: IMAP_CONNECTION_TIMEOUT,
+        greetingTimeout: IMAP_CONNECTION_TIMEOUT,
+        socketTimeout: IMAP_SOCKET_TIMEOUT,
     });
     await client.connect();
     return client;
+}
+
+// Los filtros de Gmail pueden etiquetar y archivar (saltar la bandeja de entrada) los
+// correos de proveedores, con lo que dejan de estar en INBOX. "Todos" (\All) los incluye
+// a todos (salvo Spam/Papelera) independientemente de en qué etiqueta estén.
+async function getSearchMailboxPath(client) {
+    const mailboxes = await client.list();
+    const allMail = mailboxes.find(m => m.specialUse === '\\All');
+    return allMail?.path ?? 'INBOX';
 }
 
 function matchSupplier(fromAddress, subject, knownSuppliers) {
@@ -53,7 +72,7 @@ export async function checkPendingSupplierEmails(user, password, knownSuppliers,
 
     const excluded = new Set(excludeUids);
     const client = await getClient(user, password);
-    const lock = await client.getMailboxLock('INBOX');
+    const lock = await client.getMailboxLock(await getSearchMailboxPath(client));
     try {
         const since = new Date(Date.now() - SEARCH_WINDOW_DAYS * 24 * 60 * 60 * 1000);
         const uids = await client.search({ since }, { uid: true });
@@ -70,6 +89,7 @@ export async function checkPendingSupplierEmails(user, password, knownSuppliers,
                         subject,
                         from,
                         date: msg.envelope.date,
+                        supplierId: supplier.id,
                         supplierName: supplier.name,
                         hasAttachment: !!findAttachmentPart(msg.bodyStructure),
                     });
@@ -85,7 +105,7 @@ export async function checkPendingSupplierEmails(user, password, knownSuppliers,
 
 export async function downloadSupplierEmailAttachment(user, password, uid) {
     const client = await getClient(user, password);
-    const lock = await client.getMailboxLock('INBOX');
+    const lock = await client.getMailboxLock(await getSearchMailboxPath(client));
     try {
         const message = await client.fetchOne(uid, { bodyStructure: true }, { uid: true });
         if (!message) return null;
@@ -104,7 +124,7 @@ export async function downloadSupplierEmailAttachment(user, password, uid) {
 
 export async function markSupplierEmailRead(user, password, uid) {
     const client = await getClient(user, password);
-    const lock = await client.getMailboxLock('INBOX');
+    const lock = await client.getMailboxLock(await getSearchMailboxPath(client));
     try {
         await client.messageFlagsAdd([uid], ['\\Seen'], { uid: true });
     } finally {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,6 +21,7 @@
         "mysql2": "^3.3.3",
         "nodemailer": "^6.9.2",
         "nodemon": "^3.1.0",
+        "pdf-parse": "^2.4.5",
         "pdfkit": "^0.13.0",
         "pdfmake": "^0.2.7",
         "sharp": "^0.34.5",
@@ -574,6 +575,205 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -3313,6 +3513,38 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
     },
     "node_modules/pdfkit": {
       "version": "0.13.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "mysql2": "^3.3.3",
     "nodemailer": "^6.9.2",
     "nodemon": "^3.1.0",
+    "pdf-parse": "^2.4.5",
     "pdfkit": "^0.13.0",
     "pdfmake": "^0.2.7",
     "sharp": "^0.34.5",

--- a/server/routes/facturasProveedor.js
+++ b/server/routes/facturasProveedor.js
@@ -18,7 +18,8 @@ import {
     markSupplierEmailRead,
     downloadSupplierEmailAttachment,
 } from '../mail/checkSupplierMails.js';
-import { listSuppliers } from '../suppliers/suppliers.js';
+import { listSuppliers, getSupplierById } from '../suppliers/suppliers.js';
+import { extractSupplierInvoiceFields } from '../invoices/extractSupplierInvoiceData.js';
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -44,6 +45,20 @@ function getImapCredentials() {
     return (user && pass) ? { user, pass } : null;
 }
 
+function parseVatLines(raw) {
+    if (!raw) return [];
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+        .map(l => ({ baseAmount: Number(l.baseAmount), vatRate: Number(l.vatRate) }))
+        .filter(l => Number.isFinite(l.baseAmount) && Number.isFinite(l.vatRate));
+}
+
 function parseInvoiceBody(body) {
     const num = v => (v === undefined || v === null || v === '') ? null : Number(v);
     return {
@@ -51,9 +66,7 @@ function parseInvoiceBody(body) {
         nif: body.nif || null,
         date: body.date,
         supplierName: body.supplierName,
-        baseAmount: num(body.baseAmount),
-        vatRate: num(body.vatRate),
-        vatAmount: num(body.vatAmount),
+        vatLines: parseVatLines(body.vatLines),
         totalAmount: num(body.totalAmount),
         reference: body.reference || null,
         notes: body.notes || null,
@@ -109,6 +122,29 @@ router.get('/factura/proveedor/email-pending/:uid/attachment', async function (r
     }
 });
 
+router.get('/factura/proveedor/email-pending/:uid/extract', async function (req, res) {
+    if (!adminGuard(req, res)) return;
+
+    const supplierId = Number(req.query.supplierId);
+    if (!supplierId) return res.status(400).json({ error: 'supplierId es obligatorio' });
+
+    try {
+        const credentials = getImapCredentials();
+        if (!credentials) return res.status(500).json({ error: 'Gmail IMAP no configurado' });
+        const supplier = await getSupplierById(supplierId);
+        if (!supplier) return res.sendStatus(404);
+
+        const attachment = await downloadSupplierEmailAttachment(credentials.user, credentials.pass, Number(req.params.uid));
+        if (!attachment) return res.sendStatus(404);
+
+        const fields = await extractSupplierInvoiceFields(attachment.buffer, attachment.contentType, attachment.filename, supplier);
+        res.json(fields);
+    } catch (err) {
+        console.error('Error extrayendo datos de factura de proveedor:', err);
+        res.status(500).json({ error: err.message });
+    }
+});
+
 router.get('/factura/proveedor/:id/file', async function (req, res) {
     if (!adminGuard(req, res)) return;
 
@@ -146,8 +182,9 @@ router.post('/factura/proveedor', upload.single('file'), async function (req, re
         return res.status(400).json({ message: 'date, supplierName y totalAmount son obligatorios' });
     }
 
+    let id = null;
     try {
-        const id = await createSupplierInvoice(invoice);
+        id = await createSupplierInvoice(invoice);
 
         let attachment = req.file ? { buffer: req.file.buffer, contentType: req.file.mimetype, filename: req.file.originalname } : null;
         const credentials = getImapCredentials();
@@ -172,6 +209,15 @@ router.post('/factura/proveedor', upload.single('file'), async function (req, re
         res.status(201).json({ id });
     } catch (err) {
         console.error('Error creando factura de proveedor:', err);
+        if (id) {
+            try {
+                const filePath = await getSupplierInvoiceFilePath(id);
+                if (filePath) removeInvoiceFile(filePath);
+                await deleteSupplierInvoice(id);
+            } catch (cleanupErr) {
+                console.error('Error revirtiendo factura de proveedor tras fallo:', cleanupErr);
+            }
+        }
         res.status(500).json({ error: err.message });
     }
 });

--- a/server/routes/suppliers.js
+++ b/server/routes/suppliers.js
@@ -4,6 +4,17 @@ import { listSuppliers, findSupplierByDomain, createSupplier, updateSupplier, de
 
 const router = express.Router();
 
+function parseTemplate(body) {
+    const field = v => (v ?? '').trim() || null;
+    return {
+        invoiceNumberPattern: field(body.invoiceNumberPattern),
+        nifPattern: field(body.nifPattern),
+        baseAmountPattern: field(body.baseAmountPattern),
+        vatRatePattern: field(body.vatRatePattern),
+        totalAmountPattern: field(body.totalAmountPattern),
+    };
+}
+
 router.get('/proveedores', async function (req, res) {
     if (!adminGuard(req, res)) return;
     try {
@@ -25,7 +36,7 @@ router.post('/proveedores', async function (req, res) {
     try {
         const existing = await findSupplierByDomain(domain);
         if (existing) return res.status(409).json({ message: 'Ya existe un proveedor con ese dominio' });
-        const id = await createSupplier(name, domain, subjectKeyword);
+        const id = await createSupplier(name, domain, subjectKeyword, parseTemplate(req.body));
         res.status(201).json({ id });
     } catch (err) {
         console.error('Error creando proveedor:', err);
@@ -44,7 +55,7 @@ router.put('/proveedores/:id', async function (req, res) {
     try {
         const existing = await findSupplierByDomain(domain, req.params.id);
         if (existing) return res.status(409).json({ message: 'Ya existe un proveedor con ese dominio' });
-        await updateSupplier(req.params.id, name, domain, subjectKeyword);
+        await updateSupplier(req.params.id, name, domain, subjectKeyword, parseTemplate(req.body));
         res.sendStatus(204);
     } catch (err) {
         console.error('Error actualizando proveedor:', err);

--- a/server/suppliers/suppliers.js
+++ b/server/suppliers/suppliers.js
@@ -1,10 +1,25 @@
 import executeQuery from '../sql/sqlUtils.js';
 
+const SELECT_FIELDS = `id, name, domain, subject_keyword AS subjectKeyword,
+    invoice_number_pattern AS invoiceNumberPattern,
+    nif_pattern AS nifPattern,
+    base_amount_pattern AS baseAmountPattern,
+    vat_rate_pattern AS vatRatePattern,
+    total_amount_pattern AS totalAmountPattern`;
+
 export async function listSuppliers() {
     const rows = await executeQuery(
-        'SELECT id, name, domain, subject_keyword AS subjectKeyword FROM casademiranda.suppliers ORDER BY name'
+        `SELECT ${SELECT_FIELDS} FROM casademiranda.suppliers ORDER BY name`
     );
     return rows ?? [];
+}
+
+export async function getSupplierById(id) {
+    const rows = await executeQuery(
+        `SELECT ${SELECT_FIELDS} FROM casademiranda.suppliers WHERE id = ?`,
+        [id]
+    );
+    return rows?.[0] ?? null;
 }
 
 export async function findSupplierByDomain(domain, excludeId = null) {
@@ -14,18 +29,38 @@ export async function findSupplierByDomain(domain, excludeId = null) {
     return rows?.[0] ?? null;
 }
 
-export async function createSupplier(name, domain, subjectKeyword) {
+export async function createSupplier(name, domain, subjectKeyword, template = {}) {
     const result = await executeQuery(
-        'INSERT INTO casademiranda.suppliers (name, domain, subject_keyword) VALUES (?, ?, ?)',
-        [name, domain, subjectKeyword ?? null]
+        `INSERT INTO casademiranda.suppliers
+            (name, domain, subject_keyword, invoice_number_pattern, nif_pattern, base_amount_pattern, vat_rate_pattern, total_amount_pattern)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            name, domain, subjectKeyword ?? null,
+            template.invoiceNumberPattern ?? null,
+            template.nifPattern ?? null,
+            template.baseAmountPattern ?? null,
+            template.vatRatePattern ?? null,
+            template.totalAmountPattern ?? null,
+        ]
     );
     return result.insertId;
 }
 
-export async function updateSupplier(id, name, domain, subjectKeyword) {
+export async function updateSupplier(id, name, domain, subjectKeyword, template = {}) {
     await executeQuery(
-        'UPDATE casademiranda.suppliers SET name = ?, domain = ?, subject_keyword = ? WHERE id = ?',
-        [name, domain, subjectKeyword ?? null, id]
+        `UPDATE casademiranda.suppliers
+         SET name = ?, domain = ?, subject_keyword = ?,
+             invoice_number_pattern = ?, nif_pattern = ?, base_amount_pattern = ?, vat_rate_pattern = ?, total_amount_pattern = ?
+         WHERE id = ?`,
+        [
+            name, domain, subjectKeyword ?? null,
+            template.invoiceNumberPattern ?? null,
+            template.nifPattern ?? null,
+            template.baseAmountPattern ?? null,
+            template.vatRatePattern ?? null,
+            template.totalAmountPattern ?? null,
+            id,
+        ]
     );
 }
 


### PR DESCRIPTION
## Resumen

**GH-176 — Plantillas de extracción por proveedor**
- Patrón regex por campo (nº factura, NIF, base, IVA%, total) configurable por proveedor desde "Proveedores conocidos", aplicado sobre el adjunto del correo (texto nativo de PDF vía `pdf-parse`, con fallback a OCR vía `tesseract`/`pdftoppm` para PDFs escaneados e imágenes) al pulsar "Registrar" desde un correo pendiente. El NIF extraído se normaliza (sin puntos/guiones/espacios).
- Búsqueda de correo en la carpeta "Todos" (`\All`) en vez de solo `INBOX`, para detectar también correos etiquetados/archivados por filtros de Gmail.
- Timeout en las conexiones IMAP (15s conexión, 30s socket) para fallar rápido en vez de dejar la petición colgada hasta que nginx corte con un 504.
- Rollback automático de la factura si algo falla después de crearla, para no dejar registros huérfanos en BD y permitir reintentar con un mensaje de error claro.

**GH-177 — Desglose de varios tipos de IVA por factura de proveedor**
- Nueva tabla `supplier_invoice_vat_lines` (base, tipo de IVA, cuota) por factura, en sustitución de las columnas sueltas `base_amount`/`vat_rate`/`vat_amount` de `supplier_invoices` (migradas y eliminadas).
- El formulario de alta/edición permite añadir y quitar líneas de IVA; el total se autocalcula como conveniencia pero sigue siendo un campo propio editable.
- La extracción automática sigue rellenando como mucho una línea (evita adivinar en facturas con varios tipos); para proveedores con desglose multi-tramo se añaden las líneas restantes a mano.

## Test plan
- [x] `npx tsc --noEmit` en frontend sin errores
- [x] `node --check` sobre todos los ficheros backend nuevos/tocados
- [x] Extracción probada con facturas reales (PDF nativo y PDF escaneado vía OCR) contra las plantillas construidas
- [x] Probado en navegador (Docker local): alta de proveedor con plantilla, edición y persistencia; alta de factura con varias líneas de IVA, autocálculo del total, edición y recuperación de las líneas
- [x] Migraciones aplicadas y verificadas contra MySQL local

🤖 Generated with [Claude Code](https://claude.com/claude-code)