### PR TITLE
GH-185: extraer la fecha de la factura del proveedor en vez de usar la del email

### DIFF
--- a/front/admin-casademiranda/components/contabilidad/facturas-proveedores.tsx
+++ b/front/admin-casademiranda/components/contabilidad/facturas-proveedores.tsx
@@ -135,6 +135,7 @@ export default function FacturasProveedores() {
                 const next = { ...prev };
                 if (extracted.invoiceNumber) next.invoiceNumber = extracted.invoiceNumber;
                 if (extracted.nif) next.nif = extracted.nif;
+                if (extracted.date) next.date = extracted.date;
                 if (extracted.baseAmount != null && extracted.vatRatePercent != null) {
                     next.vatLines = [{ baseAmount: String(extracted.baseAmount), vatPercent: String(extracted.vatRatePercent) }];
                 }

--- a/front/admin-casademiranda/components/contabilidad/proveedores-modal.tsx
+++ b/front/admin-casademiranda/components/contabilidad/proveedores-modal.tsx
@@ -12,6 +12,7 @@ const emptyTemplate: SupplierTemplate = {
     baseAmountPattern: null,
     vatRatePattern: null,
     totalAmountPattern: null,
+    datePattern: null,
 };
 
 const TEMPLATE_FIELDS: { key: keyof SupplierTemplate; label: string; placeholder: string }[] = [
@@ -20,6 +21,7 @@ const TEMPLATE_FIELDS: { key: keyof SupplierTemplate; label: string; placeholder
     { key: 'baseAmountPattern', label: 'Base imponible', placeholder: String.raw`Base imponible\s*([\d.,]+)` },
     { key: 'vatRatePattern', label: 'IVA %', placeholder: String.raw`IVA\s*\((\d+)%\)` },
     { key: 'totalAmountPattern', label: 'Total', placeholder: String.raw`Total factura\s*([\d.,]+)\s*€` },
+    { key: 'datePattern', label: 'Fecha', placeholder: String.raw`FECHA:\s*(\d{2}/\d{2}/\d{4})` },
 ];
 
 function TemplateFields({ value, onChange }: { value: SupplierTemplate; onChange: (t: SupplierTemplate) => void }) {
@@ -109,6 +111,7 @@ export default function ProveedoresModal({ onClose }: Props) {
             baseAmountPattern: s.baseAmountPattern,
             vatRatePattern: s.vatRatePattern,
             totalAmountPattern: s.totalAmountPattern,
+            datePattern: s.datePattern,
         });
         setShowEditTemplate(false);
         setEditDomain(s.domain);

--- a/front/admin-casademiranda/interfaces/supplier.ts
+++ b/front/admin-casademiranda/interfaces/supplier.ts
@@ -8,6 +8,7 @@ export interface Supplier {
     baseAmountPattern: string | null;
     vatRatePattern: string | null;
     totalAmountPattern: string | null;
+    datePattern: string | null;
 }
 
 export interface SupplierTemplate {
@@ -16,4 +17,5 @@ export interface SupplierTemplate {
     baseAmountPattern: string | null;
     vatRatePattern: string | null;
     totalAmountPattern: string | null;
+    datePattern: string | null;
 }

--- a/front/admin-casademiranda/interfaces/supplierInvoice.ts
+++ b/front/admin-casademiranda/interfaces/supplierInvoice.ts
@@ -51,4 +51,5 @@ export interface ExtractedInvoiceData {
     baseAmount: number | null;
     vatRatePercent: number | null;
     totalAmount: number | null;
+    date: string | null;
 }

--- a/infrastructure/bbdd/migrations/GH-185-supplier-date-pattern.sql
+++ b/infrastructure/bbdd/migrations/GH-185-supplier-date-pattern.sql
@@ -1,0 +1,2 @@
+ALTER TABLE casademiranda.suppliers
+  ADD COLUMN date_pattern VARCHAR(255) NULL;

--- a/server/invoices/extractSupplierInvoiceData.js
+++ b/server/invoices/extractSupplierInvoiceData.js
@@ -108,6 +108,14 @@ function cleanNif(str) {
     return cleaned || null;
 }
 
+function normalizeSpanishDate(str) {
+    if (!str) return null;
+    const match = /^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/.exec(str.trim());
+    if (!match) return null;
+    const [, day, month, year] = match;
+    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
 function applyInvoiceTemplate(text, template) {
     return {
         invoiceNumber: extractField(text, template.invoiceNumberPattern),
@@ -115,10 +123,11 @@ function applyInvoiceTemplate(text, template) {
         baseAmount: parseSpanishNumber(extractField(text, template.baseAmountPattern)),
         vatRatePercent: parseSpanishNumber(extractField(text, template.vatRatePattern)),
         totalAmount: parseSpanishNumber(extractField(text, template.totalAmountPattern)),
+        date: normalizeSpanishDate(extractField(text, template.datePattern)),
     };
 }
 
-const EMPTY_RESULT = { invoiceNumber: null, nif: null, baseAmount: null, vatRatePercent: null, totalAmount: null };
+const EMPTY_RESULT = { invoiceNumber: null, nif: null, baseAmount: null, vatRatePercent: null, totalAmount: null, date: null };
 
 export async function extractSupplierInvoiceFields(buffer, contentType, filename, template) {
     try {

--- a/server/routes/suppliers.js
+++ b/server/routes/suppliers.js
@@ -12,6 +12,7 @@ function parseTemplate(body) {
         baseAmountPattern: field(body.baseAmountPattern),
         vatRatePattern: field(body.vatRatePattern),
         totalAmountPattern: field(body.totalAmountPattern),
+        datePattern: field(body.datePattern),
     };
 }
 

--- a/server/suppliers/suppliers.js
+++ b/server/suppliers/suppliers.js
@@ -5,7 +5,8 @@ const SELECT_FIELDS = `id, name, domain, subject_keyword AS subjectKeyword,
     nif_pattern AS nifPattern,
     base_amount_pattern AS baseAmountPattern,
     vat_rate_pattern AS vatRatePattern,
-    total_amount_pattern AS totalAmountPattern`;
+    total_amount_pattern AS totalAmountPattern,
+    date_pattern AS datePattern`;
 
 export async function listSuppliers() {
     const rows = await executeQuery(
@@ -32,8 +33,8 @@ export async function findSupplierByDomain(domain, excludeId = null) {
 export async function createSupplier(name, domain, subjectKeyword, template = {}) {
     const result = await executeQuery(
         `INSERT INTO casademiranda.suppliers
-            (name, domain, subject_keyword, invoice_number_pattern, nif_pattern, base_amount_pattern, vat_rate_pattern, total_amount_pattern)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            (name, domain, subject_keyword, invoice_number_pattern, nif_pattern, base_amount_pattern, vat_rate_pattern, total_amount_pattern, date_pattern)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
             name, domain, subjectKeyword ?? null,
             template.invoiceNumberPattern ?? null,
@@ -41,6 +42,7 @@ export async function createSupplier(name, domain, subjectKeyword, template = {}
             template.baseAmountPattern ?? null,
             template.vatRatePattern ?? null,
             template.totalAmountPattern ?? null,
+            template.datePattern ?? null,
         ]
     );
     return result.insertId;
@@ -50,7 +52,7 @@ export async function updateSupplier(id, name, domain, subjectKeyword, template 
     await executeQuery(
         `UPDATE casademiranda.suppliers
          SET name = ?, domain = ?, subject_keyword = ?,
-             invoice_number_pattern = ?, nif_pattern = ?, base_amount_pattern = ?, vat_rate_pattern = ?, total_amount_pattern = ?
+             invoice_number_pattern = ?, nif_pattern = ?, base_amount_pattern = ?, vat_rate_pattern = ?, total_amount_pattern = ?, date_pattern = ?
          WHERE id = ?`,
         [
             name, domain, subjectKeyword ?? null,
@@ -59,6 +61,7 @@ export async function updateSupplier(id, name, domain, subjectKeyword, template 
             template.baseAmountPattern ?? null,
             template.vatRatePattern ?? null,
             template.totalAmountPattern ?? null,
+            template.datePattern ?? null,
             id,
         ]
     );


### PR DESCRIPTION
## Resumen
- Añade la columna `date_pattern` a `suppliers` (migración `GH-185-supplier-date-pattern.sql`) para que cada proveedor defina un patrón que extraiga la fecha real de la factura.
- `extractSupplierInvoiceData.js` extrae y normaliza esa fecha (`DD/MM/YYYY` → `YYYY-MM-DD`).
- Al registrar una factura desde un correo detectado, la fecha extraída del documento prevalece sobre la fecha del email; esta última queda solo como valor de respaldo si el documento no trae fecha reconocible.
- UI: nuevo campo "Fecha" en la plantilla de extracción del modal de Proveedores.

Cierra #185

## Plan de pruebas
- [x] `node --check` en los archivos de backend modificados
- [x] `tsc --noEmit` sin errores en el frontend
- [x] Migración aplicada y verificada contra el docker de MySQL local (`DESCRIBE casademiranda.suppliers`)
- [x] Extracción/normalización de fecha probada con el ejemplo real de la issue (factura de Panadería Pichín)
- [x] Probar en la UI real: leer correo de un proveedor con `date_pattern` configurado y comprobar que el formulario rellena la fecha del documento, no la del email

🤖 Generated with [Claude Code](https://claude.com/claude-code)