### PR TITLE
GH-184: evitar que el email largo del huésped pise la fecha de check-in

### DIFF
--- a/front/admin-casademiranda/components/clients/clientComponent.tsx
+++ b/front/admin-casademiranda/components/clients/clientComponent.tsx
@@ -13,7 +13,7 @@ function Field({ label, value }: { label: string; value?: string | number | null
     return (
         <div>
             <p className="text-xs text-gray uppercase tracking-wide">{label}</p>
-            <p className="text-gray-dark font-medium">{value || '—'}</p>
+            <p className="text-gray-dark font-medium break-words">{value || '—'}</p>
         </div>
     );
 }


### PR DESCRIPTION
## Resumen
- En la ficha de huésped de una reserva (sección "Contacto" de `ClientComponent`), el email y la fecha de check-in se muestran en celdas contiguas de un grid de 4 columnas.
- El párrafo de valor (`Field`) no tenía control de desbordamiento, así que un email largo sin espacios se salía de su columna y se solapaba visualmente con "Fecha check-in".
- Fix: añadida la clase `break-words` al párrafo de valor, aplicable a todos los campos del componente (no solo email).

Cierra #184

## Plan de pruebas
- [x] `tsc --noEmit` sin errores
- [x] Repliqué la estructura exacta del grid en un HTML aislado (mismas clases, email largo de ejemplo) y comparé antes/después con Playwright — confirmado visualmente que el solapamiento desaparece
- [x] Verificar en la app real abriendo una reserva con un huésped que tenga un email largo

🤖 Generated with [Claude Code](https://claude.com/claude-code)