### PR TITLE
GH-182: validar formato de email y detectar erratas en dominios conocidos

### DIFF
--- a/front/admin-casademiranda/pages/booking/[id].tsx
+++ b/front/admin-casademiranda/pages/booking/[id].tsx
@@ -21,6 +21,7 @@ import Link from 'next/link'
 import { Client } from '@/interfaces/client';
 import ClientComponent from '@/components/clients/clientComponent';
 import DateComponent from '@/components/dates/dateComponent';
+import { isValidEmailFormat, suggestEmailCorrection } from '@/utils/email';
 
 function validateClientForCheckin(c: Client): string[] {
     const errors: string[] = [];
@@ -106,6 +107,8 @@ export default function BookingPage() {
     const [billConcepto, setBillConcepto] = useState('');
     const [billExtras, setBillExtras] = useState<BillExtra[]>([]);
     const [billEmail, setBillEmail] = useState('');
+    const [billEmailError, setBillEmailError] = useState('');
+    const [billEmailSuggestion, setBillEmailSuggestion] = useState<string | null>(null);
     const [billEnviarACliente, setBillEnviarACliente] = useState(false);
     const [billNombreEmpresa, setBillNombreEmpresa] = useState('');
     const [billCodigoPostalCiudad, setBillCodigoPostalCiudad] = useState('');
@@ -205,7 +208,17 @@ export default function BookingPage() {
         };
     }
 
+    function validateBillEmail(): boolean {
+        if (billEmail.trim() && !isValidEmailFormat(billEmail)) {
+            setBillEmailError('Formato de email no válido');
+            return false;
+        }
+        setBillEmailError('');
+        return true;
+    }
+
     async function handlePreviewBill() {
+        if (!validateBillEmail()) return;
         const bill = buildBillPayload();
         if (!bill) return;
         setBillPreviewing(true);
@@ -221,6 +234,7 @@ export default function BookingPage() {
     }
 
     async function handleCreateBill() {
+        if (!validateBillEmail()) return;
         const bill = buildBillPayload();
         if (!bill) return;
         setBillLoading(true);
@@ -627,7 +641,21 @@ export default function BookingPage() {
                                         )}
                                         <div className="sm:col-span-2">
                                             <label className={labelClass}>Email destinatario</label>
-                                            <input className={inputClass} type="email" value={billEmail} onChange={e => setBillEmail(e.target.value)} placeholder="email@ejemplo.com" />
+                                            <input className={inputClass} type="email" value={billEmail}
+                                                onChange={e => {
+                                                    setBillEmail(e.target.value);
+                                                    setBillEmailError('');
+                                                    setBillEmailSuggestion(suggestEmailCorrection(e.target.value));
+                                                }} placeholder="email@ejemplo.com" />
+                                            {billEmailError && <p className="text-xs text-orange mt-1">{billEmailError}</p>}
+                                            {!billEmailError && billEmailSuggestion && (
+                                                <p className="text-xs text-orange mt-1">
+                                                    ¿Quisiste decir{' '}
+                                                    <button type="button" className="underline" onClick={() => { setBillEmail(billEmailSuggestion); setBillEmailSuggestion(null); }}>
+                                                        {billEmailSuggestion}
+                                                    </button>?
+                                                </p>
+                                            )}
                                             <label className="flex items-center gap-2 mt-2 text-xs text-gray-dark">
                                                 <input
                                                     type="checkbox"

--- a/front/admin-casademiranda/pages/booking/new-booking.tsx
+++ b/front/admin-casademiranda/pages/booking/new-booking.tsx
@@ -6,6 +6,7 @@ import type { RequestRoom } from '@/interfaces/room';
 import * as APIBooking from "../../services/bookings";
 import * as APIRoomPrices from "../../services/roomPrices";
 import { getRoomsAvailability } from "../../services/bookings";
+import { isValidEmailFormat, suggestEmailCorrection } from "@/utils/email";
 
 const ALL_ROOMS = ['A Fonte', 'O Carpinteiro', 'O Cuberto', 'O Faiado'];
 import { useRouter } from 'next/router';
@@ -26,6 +27,7 @@ export default function NewBooking() {
     const [surname2, setSurname2] = useState("");
     const [identifier, setIdentifier] = useState("");
     const [email, setEmail] = useState("");
+    const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null);
     const [confirmedEmail, setConfirmedEmail] = useState("");
     const [sendEmail, setSendEmail] = useState<boolean>(false);
     const [checkIn, setCheckIn] = useState("");
@@ -106,7 +108,7 @@ export default function NewBooking() {
 
         if (!email.trim()) {
             e.email = 'El email es obligatorio';
-        } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        } else if (!isValidEmailFormat(email)) {
             e.email = 'Formato de email no válido';
         } else if (email !== confirmedEmail) {
             e.confirmedEmail = 'Los emails no coinciden';
@@ -194,8 +196,20 @@ export default function NewBooking() {
                             <div>
                                 <label className={labelClass}>Email *</label>
                                 <input className={f('email')} type="email" value={email}
-                                    onChange={e => { setEmail(e.target.value); clearError('email'); clearError('confirmedEmail'); }} />
+                                    onChange={e => {
+                                        setEmail(e.target.value);
+                                        clearError('email'); clearError('confirmedEmail');
+                                        setEmailSuggestion(suggestEmailCorrection(e.target.value));
+                                    }} />
                                 {errors.email && <p className={errorClass}>{errors.email}</p>}
+                                {!errors.email && emailSuggestion && (
+                                    <p className={errorClass}>
+                                        ¿Quisiste decir{' '}
+                                        <button type="button" className="underline" onClick={() => { setEmail(emailSuggestion); setEmailSuggestion(null); }}>
+                                            {emailSuggestion}
+                                        </button>?
+                                    </p>
+                                )}
                             </div>
                             <div>
                                 <label className={labelClass}>Confirmar email *</label>

--- a/front/admin-casademiranda/pages/client/new-client.tsx
+++ b/front/admin-casademiranda/pages/client/new-client.tsx
@@ -12,6 +12,7 @@ import { findMunicipioByName } from '@/utils/municipioSearch';
 import { MunicipioSelector } from '@/components/clients/MunicipioSelector';
 import { PostalCodeSelector } from '@/components/clients/PostalCodeSelector';
 import { PaisSelector } from '@/components/clients/PaisSelector';
+import { isValidEmailFormat, suggestEmailCorrection } from '@/utils/email';
 
 type Country = {
     pais: string;
@@ -40,6 +41,7 @@ export default function NewClient() {
     const [phone, setPhone] = useState("");
     const [otherPhone, setOtherPhone] = useState("");
     const [email, setEmail] = useState("");
+    const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null);
     const [relationship, setRelationship] = useState("");
     const [line, setLine] = useState("");
     const [line2, setLine2] = useState("");
@@ -60,6 +62,7 @@ export default function NewClient() {
     const [backFile, setBackFile] = useState<File | null>(null);
 
     const validData = (client: Client) => {
+        if (client.email && !isValidEmailFormat(client.email)) return false;
         return true;
     }
 
@@ -140,7 +143,7 @@ export default function NewClient() {
 
         if (!validData(client)) {
 
-            alert('Los datos del cliente no son validos')
+            alert('El email no tiene un formato válido')
             return new Error('Invalid client data')
         }
 
@@ -297,7 +300,16 @@ export default function NewClient() {
 
                         <div className="grid grid-cols-1">
                             <label className='text-gray-dark text-opacity-75' id="email">Email:</label>
-                            <input type="text" className='rounded-full' id="email" name="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+                            <input type="email" className='rounded-full' id="email" name="email" value={email}
+                                onChange={(e) => { setEmail(e.target.value); setEmailSuggestion(suggestEmailCorrection(e.target.value)); }} />
+                            {emailSuggestion && (
+                                <p className="text-xs text-orange mt-1">
+                                    ¿Quisiste decir{' '}
+                                    <button type="button" className="underline" onClick={() => { setEmail(emailSuggestion); setEmailSuggestion(null); }}>
+                                        {emailSuggestion}
+                                    </button>?
+                                </p>
+                            )}
                         </div>
                         
                         <div className="grid grid-cols-1">

--- a/front/admin-casademiranda/pages/client/update-client/[id].tsx
+++ b/front/admin-casademiranda/pages/client/update-client/[id].tsx
@@ -11,6 +11,7 @@ import { findMunicipioByName } from '@/utils/municipioSearch';
 import { MunicipioSelector } from '@/components/clients/MunicipioSelector';
 import { PostalCodeSelector } from '@/components/clients/PostalCodeSelector';
 import { PaisSelector } from '@/components/clients/PaisSelector';
+import { isValidEmailFormat, suggestEmailCorrection } from '@/utils/email';
 
 type Country = {
     pais: string;
@@ -41,6 +42,7 @@ export default function UpdateClient() {
     const [scanning, setScanning] = useState(false);
     const [scanError, setScanError] = useState('');
     const [backFile, setBackFile] = useState<File | null>(null);
+    const [emailSuggestion, setEmailSuggestion] = useState<string | null>(null);
 
 
 
@@ -101,6 +103,9 @@ export default function UpdateClient() {
         if (client === undefined) {
             return false;
         }
+        if (client.email && !isValidEmailFormat(client.email)) {
+            return false;
+        }
         return true;
     }
 
@@ -124,7 +129,7 @@ export default function UpdateClient() {
 
         if (!validData(client)) {
 
-            alert('Los datos del cliente no son validos')
+            alert('El email no tiene un formato válido')
             return new Error('Invalid client data')
         }
 
@@ -256,7 +261,16 @@ export default function UpdateClient() {
 
                             <div className="grid grid-cols-1">
                                 <label className='text-gray-dark text-opacity-75' id="email">Email:</label>
-                                <input type="text" className='rounded-full' id="email" name="email" value={client.email} onChange={(e) => setClient({ ...client, email: e.target.value })} />
+                                <input type="email" className='rounded-full' id="email" name="email" value={client.email}
+                                    onChange={(e) => { setClient({ ...client, email: e.target.value }); setEmailSuggestion(suggestEmailCorrection(e.target.value)); }} />
+                                {emailSuggestion && (
+                                    <p className="text-xs text-orange mt-1">
+                                        ¿Quisiste decir{' '}
+                                        <button type="button" className="underline" onClick={() => { setClient({ ...client, email: emailSuggestion }); setEmailSuggestion(null); }}>
+                                            {emailSuggestion}
+                                        </button>?
+                                    </p>
+                                )}
                             </div>
                             <div className="grid grid-cols-1">
                                 <label className='text-gray-dark text-opacity-75' id="relationship">Parentesco:</label>

--- a/front/admin-casademiranda/utils/email.ts
+++ b/front/admin-casademiranda/utils/email.ts
@@ -1,0 +1,45 @@
+const EMAIL_FORMAT = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
+
+// Dominios habituales usados para detectar erratas (lista estática, sin resolución DNS).
+const KNOWN_DOMAINS = [
+    'gmail.com', 'hotmail.com', 'hotmail.es', 'outlook.com', 'outlook.es',
+    'yahoo.com', 'yahoo.es', 'icloud.com', 'live.com', 'msn.com', 'aol.com',
+    'protonmail.com', 'terra.es', 'telefonica.net', 'movistar.es', 'wanadoo.es',
+];
+
+export function isValidEmailFormat(email: string): boolean {
+    return EMAIL_FORMAT.test(email.trim());
+}
+
+function levenshtein(a: string, b: string): number {
+    const m = a.length, n = b.length;
+    const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+    for (let i = 0; i <= m; i++) dp[i][0] = i;
+    for (let j = 0; j <= n; j++) dp[0][j] = j;
+    for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+            dp[i][j] = a[i - 1] === b[j - 1]
+                ? dp[i - 1][j - 1]
+                : 1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]);
+        }
+    }
+    return dp[m][n];
+}
+
+// Si el dominio se parece mucho a uno conocido pero no coincide, sugiere la corrección
+// (p.ej. "user@gmial.com" -> "user@gmail.com"). No bloquea dominios propios/desconocidos.
+export function suggestEmailCorrection(email: string): string | null {
+    const at = email.lastIndexOf('@');
+    if (at === -1) return null;
+    const domain = email.slice(at + 1).toLowerCase().trim();
+    if (!domain || KNOWN_DOMAINS.includes(domain)) return null;
+
+    let best: { domain: string; distance: number } | null = null;
+    for (const known of KNOWN_DOMAINS) {
+        const distance = levenshtein(domain, known);
+        if (distance > 0 && distance <= 2 && (!best || distance < best.distance)) {
+            best = { domain: known, distance };
+        }
+    }
+    return best ? `${email.slice(0, at + 1)}${best.domain}` : null;
+}

--- a/server/routes/clientes.js
+++ b/server/routes/clientes.js
@@ -2,11 +2,16 @@ import express from 'express';
 import { authGuard } from '../middleware/auth.js';
 import { save, update } from '../clients/saveClient.js';
 import { listAllCustomers, listCustomerById, listCustomerByBookingId, listCustomerByIdentifier } from '../clients/listClient.js';
+import { isValidEmailFormat } from '../validation/email.js';
 
 const router = express.Router();
 
 router.post('/cliente', async (req, res) => {
     if (!authGuard(req, res)) return;
+
+    if (req.body.email && !isValidEmailFormat(req.body.email)) {
+        return res.status(400).json({ message: 'El email no tiene un formato válido' });
+    }
 
     console.log('query: ', JSON.stringify(req.query));
 
@@ -41,6 +46,10 @@ router.post('/cliente', async (req, res) => {
 
 router.put('/cliente', async (req, res) => {
     if (!authGuard(req, res)) return;
+
+    if (req.body.email && !isValidEmailFormat(req.body.email)) {
+        return res.status(400).json({ message: 'El email no tiene un formato válido' });
+    }
 
     console.log('query: ', JSON.stringify(req.query));
 

--- a/server/routes/facturas.js
+++ b/server/routes/facturas.js
@@ -7,6 +7,7 @@ import listInvoices from '../invoices/listInvoices.js';
 import { getInformeResumen } from '../invoices/informeGestoria.js';
 import { generateInformeExcel } from '../excel/generateInformeGestoria.js';
 import executeQuery from '../sql/sqlUtils.js';
+import { isValidEmailFormat } from '../validation/email.js';
 
 const router = express.Router();
 
@@ -65,6 +66,10 @@ router.post('/factura/preview', async function (req, res) {
 
 router.post('/factura', async function (req, res) {
     if (!authGuard(req, res)) return;
+
+    if (req.body.email && !isValidEmailFormat(req.body.email)) {
+        return res.status(400).json({ message: 'El email no tiene un formato válido' });
+    }
 
     const { reserva, cliente } = parseBillBody(req.body);
     await generarFactura(reserva, cliente);

--- a/server/routes/reservas.js
+++ b/server/routes/reservas.js
@@ -11,6 +11,7 @@ import sendConfirmationBookingMail from '../confirmacion-reserva/sendMailConfirm
 import { checkAllRoomsAvailability } from '../bookings/checkAvailability.js';
 import { listBookingDishes, addBookingDish, removeBookingDish } from '../bookings/bookingDishes.js';
 import executeQuery from '../sql/sqlUtils.js';
+import { isValidEmailFormat } from '../validation/email.js';
 
 const router = express.Router();
 
@@ -57,6 +58,10 @@ router.get('/reserva', async (req, res) => {
 
 router.post('/reserva', async (req, res) => {
     if (!authGuard(req, res)) return;
+
+    if (!isValidEmailFormat(req.body.email)) {
+        return res.status(400).json({ message: 'El email no tiene un formato válido' });
+    }
 
     console.log('query: ', JSON.stringify(req.query));
 

--- a/server/validation/email.js
+++ b/server/validation/email.js
@@ -1,0 +1,5 @@
+const EMAIL_FORMAT = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
+
+export function isValidEmailFormat(email) {
+    return typeof email === 'string' && EMAIL_FORMAT.test(email.trim());
+}


### PR DESCRIPTION
## Resumen
Se pidió validar los emails, sobre todo que el dominio sea correcto. Alcance acordado: formato estricto + detección de erratas contra una lista **estática** de dominios conocidos (sin resolución DNS/MX en vivo).

- `server/validation/email.js`: validador de formato compartido (estructura `local@dominio.tld`, sin puntos dobles, TLD de 2+ letras).
- Aplicado como guardia en el backend en `POST /reserva`, `POST/PUT /cliente` y `POST /factura` (400 si el formato es inválido), para que no se pueda colar un email mal formado saltándose el frontend.
- `front/admin-casademiranda/utils/email.ts`: mismo validador de formato + `suggestEmailCorrection()`, que compara el dominio contra una lista estática de dominios habituales (gmail.com, hotmail.com, outlook.com, yahoo.com...) por distancia de Levenshtein y sugiere la corrección si se parece mucho a uno conocido pero no coincide (p.ej. `gmial.com` → `gmail.com`). No bloquea dominios propios/desconocidos.
- Aplicado en los 4 puntos donde se captura un email:
  - `new-booking.tsx`: sustituye la regex floja que ya tenía.
  - `new-client.tsx` y `update-client/[id].tsx`: no tenían ninguna validación.
  - Modal "Generar Factura" en `booking/[id].tsx`: el email nunca se validaba porque los botones no están dentro de un `<form>`, así que la validación nativa del navegador no llegaba a dispararse.

Cierra #182

## Plan de pruebas
- [x] `tsc --noEmit` sin errores
- [x] Regex probada con 12 casos válidos/inválidos (dominio con puntos dobles, TLD de 1 letra, espacios, doble `@`, guiones al borde de etiqueta...)
- [x] Sugerencia de dominio probada: detecta `gmial.com`, `hotmial.com`, `otlook.com`; no toca `miempresa.com` ni dominios ya correctos
- [x] Verificado contra el docker de MySQL/backend local: `POST /reserva`, `POST /cliente` y `POST /factura` devuelven 400 con un email mal formado, y aceptan uno válido sin bloquear de más
- [x] Probar en la UI real los 4 formularios (nueva reserva, añadir/editar huésped, generar factura)

🤖 Generated with [Claude Code](https://claude.com/claude-code)